### PR TITLE
Frontend Fixes

### DIFF
--- a/app/javascript/components/base/base-button-component.vue
+++ b/app/javascript/components/base/base-button-component.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    class="mx-2 my-2 h-10 font-bold py-2 px-6 rounded shadow-md"
+    class="mx-2 my-2 h-10 font-bold py-2 px-6 rounded shadow-md flex-shrink-0"
     :class="elements.color"
     @click="clickButton"
   >

--- a/app/javascript/components/base/base-table-component.vue
+++ b/app/javascript/components/base/base-table-component.vue
@@ -14,7 +14,7 @@
     <tbody class="bg-gray-200">
       <tr
         v-for="parsedElement in parsedElements"
-        :key="parsedElement"
+        :key="parsedElement.Nombre"
         class="bg-white border-4 border-gray-200"
       >
         <td
@@ -35,7 +35,7 @@
               edit:true,
               del:true
             }"
-            @edit="editIngredient(element)"
+            @edit="editIngredient(parsedElement)"
             @del="deleteIngredient"
           />
         </td>

--- a/app/javascript/components/base/base-table-component.vue
+++ b/app/javascript/components/base/base-table-component.vue
@@ -35,7 +35,7 @@
               edit:true,
               del:true
             }"
-            @edit="editIngredient"
+            @edit="editIngredient(element)"
             @del="deleteIngredient"
           />
         </td>
@@ -52,8 +52,8 @@ export default {
     dots: { type: Boolean, required: true },
   },
   methods: {
-    editIngredient() {
-      this.$emit('edit');
+    editIngredient(element) {
+      this.$emit('edit', element);
     },
     deleteIngredient() {
       this.$emit('del');

--- a/app/javascript/components/ingredients/base-component.vue
+++ b/app/javascript/components/ingredients/base-component.vue
@@ -83,7 +83,7 @@ export default {
       showingAdd: false,
       showingEdit: false,
       showingDel: false,
-      ingredientToEdit: '',
+      ingredientToEdit: {},
     };
   },
   methods: {

--- a/app/javascript/components/ingredients/base-component.vue
+++ b/app/javascript/components/ingredients/base-component.vue
@@ -54,6 +54,7 @@
       <ingredients-form
         :units="['Kg','Litro']"
         :edit-mode="true"
+        :ingredient="this.ingredientToEdit"
       />
     </base-modal>
 
@@ -82,14 +83,16 @@ export default {
       showingAdd: false,
       showingEdit: false,
       showingDel: false,
+      ingredientToEdit: '',
     };
   },
   methods: {
     toggleAddModal() {
       this.showingAdd = !this.showingAdd;
     },
-    toggleEditModal() {
+    toggleEditModal(ingredient) {
       this.showingEdit = !this.showingEdit;
+      this.ingredientToEdit = ingredient;
     },
     toggleDelModal() {
       this.showingDel = !this.showingDel;

--- a/app/javascript/components/ingredients/base-form-component.vue
+++ b/app/javascript/components/ingredients/base-form-component.vue
@@ -7,6 +7,8 @@
             id="ingredient-name"
             type="text"
             placeholder="Nombre"
+            :value="editMode? ingredientObject.Nombre : ''"
+
           />
         </div>
       </div>
@@ -17,6 +19,7 @@
             id="ingredient-amount"
             type="number"
             placeholder="Cantidad"
+            :value="editMode? ingredientObject.Cantidad : ''"
           />
         </div>
         <div class="relative">
@@ -25,19 +28,42 @@
             rounded leading-tight focus:outline-none"
             id="ingredient-unit"
           >
+          <!--Add Mode -->
             <option
+              v-if="!editMode" 
               hidden
               selected
             >
               Unidad
             </option>
             <option
+              v-if="!editMode" 
               v-for="unit in units"
               :key="unit"
+              :value="unit"
+            >
+              {{ unit }}
+            </option>
+
+          <!--Edit Mode -->
+            <option
+              v-if="editMode" 
+              selected
+              :key="ingredientObject.Unidad"
+              :value="ingredientObject.Unidad"
+            >
+              {{ ingredientObject.Unidad }}
+            </option>
+            <option
+              v-for="unit in units"
+              v-if="editMode && unit!=ingredientObject.Unidad" 
+              :key="unit"
+              :value="unit"
             >
               {{ unit }}
             </option>
           </select>
+
           <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
             <svg
               class="fill-current h-4 w-4"
@@ -54,6 +80,7 @@
             id="ingredient-price"
             type="number"
             placeholder="Precio"
+            :value="editMode? ingredientObject.Precio : ''"
           />
         </div>
       </div>
@@ -68,19 +95,17 @@ export default {
     editMode: {
       type: Boolean,
       required: true },
-    ingredientData: {
-      type: Object,
-      default() {
-        return {
-          Nombre: 'Manzana',
-          Precio: 1000,
-          Cantidad: 1.5,
-          Unidad: 'kg',
-          PrecioUnitario: 667,
-        };
-      },
+    ingredient: {
+      type: String,
     },
     units: { type: Array, required: true },
   },
+
+  computed: {
+    ingredientObject(){
+      return JSON.parse(this.ingredient);
+    },
+  },
 };
+
 </script>

--- a/app/javascript/components/ingredients/base-form-component.vue
+++ b/app/javascript/components/ingredients/base-form-component.vue
@@ -7,7 +7,7 @@
             id="ingredient-name"
             type="text"
             placeholder="Nombre"
-            :value="editMode? ingredient.Nombre : ''"
+            :value="editMode ? ingredient.Nombre : ''"
           />
         </div>
       </div>
@@ -18,7 +18,7 @@
             id="ingredient-amount"
             type="number"
             placeholder="Cantidad"
-            :value="editMode? ingredient.Cantidad : ''"
+            :value="editMode ? ingredient.Cantidad : ''"
           />
         </div>
         <div class="relative">

--- a/app/javascript/components/ingredients/base-form-component.vue
+++ b/app/javascript/components/ingredients/base-form-component.vue
@@ -7,8 +7,7 @@
             id="ingredient-name"
             type="text"
             placeholder="Nombre"
-            :value="editMode? ingredientObject.Nombre : ''"
-
+            :value="editMode? ingredient.Nombre : ''"
           />
         </div>
       </div>
@@ -19,7 +18,7 @@
             id="ingredient-amount"
             type="number"
             placeholder="Cantidad"
-            :value="editMode? ingredientObject.Cantidad : ''"
+            :value="editMode? ingredient.Cantidad : ''"
           />
         </div>
         <div class="relative">
@@ -28,35 +27,26 @@
             rounded leading-tight focus:outline-none"
             id="ingredient-unit"
           >
-          <!--Add Mode -->
+            <!--Add Mode unit Unselected -->
             <option
-              v-if="!editMode" 
+              v-if="!editMode"
               hidden
               selected
             >
               Unidad
             </option>
+            <!--Edit Mode unit ingredient -->
             <option
-              v-if="!editMode" 
-              v-for="unit in units"
-              :key="unit"
-              :value="unit"
-            >
-              {{ unit }}
-            </option>
-
-          <!--Edit Mode -->
-            <option
-              v-if="editMode" 
+              v-if="editMode"
               selected
-              :key="ingredientObject.Unidad"
-              :value="ingredientObject.Unidad"
+              :key="ingredient.Unidad"
+              :value="ingredient.Unidad"
             >
-              {{ ingredientObject.Unidad }}
+              {{ ingredient.Unidad }}
             </option>
+            <!--Other units -->
             <option
-              v-for="unit in units"
-              v-if="editMode && unit!=ingredientObject.Unidad" 
+              v-for="unit in formUnits"
               :key="unit"
               :value="unit"
             >
@@ -80,7 +70,7 @@
             id="ingredient-price"
             type="number"
             placeholder="Precio"
-            :value="editMode? ingredientObject.Precio : ''"
+            :value="editMode? ingredient.Precio : ''"
           />
         </div>
       </div>
@@ -92,18 +82,20 @@
 
 export default {
   props: {
-    editMode: {
-      type: Boolean,
-      required: true },
-    ingredient: {
-      type: String,
-    },
+    editMode: { type: Boolean, required: true },
+    ingredient: { type: Object, default() {
+      return {};
+    } },
     units: { type: Array, required: true },
   },
 
   computed: {
-    ingredientObject(){
-      return JSON.parse(this.ingredient);
+    formUnits() {
+      if (!this.editMode) {
+        return this.units;
+      }
+
+      return this.units.filter(unit => unit !== this.ingredient.Unidad);
     },
   },
 };

--- a/app/javascript/components/ingredients/base-input-form.vue
+++ b/app/javascript/components/ingredients/base-input-form.vue
@@ -14,7 +14,7 @@ export default {
     id: { type: String, required: true },
     type: { type: String, required: true },
     placeholder: { type: String, required: true },
-    value: { required: true},
+    value: { type: [String, Number], required: true },
   },
 };
 </script>

--- a/app/javascript/components/ingredients/base-input-form.vue
+++ b/app/javascript/components/ingredients/base-input-form.vue
@@ -4,6 +4,7 @@
     :id="id"
     :type="type"
     :placeholder="placeholder"
+    :value="value"
   >
 </template>
 
@@ -13,6 +14,7 @@ export default {
     id: { type: String, required: true },
     type: { type: String, required: true },
     placeholder: { type: String, required: true },
+    value: { required: true},
   },
 };
 </script>

--- a/app/views/ingredients/index.html.erb
+++ b/app/views/ingredients/index.html.erb
@@ -1,10 +1,12 @@
-<side-navbar active-element = "Ingredientes"></side-navbar>
-<div class="container mx-auto px-60 py-10">
-    <ingredients
-      :ingredients="<%= [
-        {"Nombre": "Manzana","Precio": 1000, "Cantidad": 1.5, "Unidad": "kg", "Precio Unitario": 667}.to_json,
-        {"Nombre": "Arándanos","Precio": 7000, "Cantidad": 1, "Unidad": "kg", "Precio Unitario": 7000}.to_json,
-        {"Nombre": "Leche","Precio": 400, "Cantidad": 1, "Unidad": "kg", "Precio Unitario": 400}.to_json] %>"
-    >
-    </ingredients>
+<div class="h-screen flex">
+  <side-navbar active-element = "Ingredientes"></side-navbar>
+  <div class="container ml-64 px-20 py-10 overflow-hidden">
+      <ingredients
+        :ingredients="<%= [
+          {"Nombre": "Manzana","Precio": 1000, "Cantidad": 1.5, "Unidad": "kg", "Precio Unitario": 667}.to_json,
+          {"Nombre": "Arándanos","Precio": 7000, "Cantidad": 1, "Unidad": "kg", "Precio Unitario": 7000}.to_json,
+          {"Nombre": "Leche","Precio": 400, "Cantidad": 1, "Unidad": "kg", "Precio Unitario": 400}.to_json] %>"
+      >
+      </ingredients>
+  </div>
 </div>

--- a/app/views/ingredients/index.html.erb
+++ b/app/views/ingredients/index.html.erb
@@ -3,9 +3,9 @@
   <div class="container ml-64 px-20 py-10 overflow-hidden">
       <ingredients
         :ingredients="<%= [
-          {"Nombre": "Manzana","Precio": 1000, "Cantidad": 1.5, "Unidad": "kg", "Precio Unitario": 667}.to_json,
-          {"Nombre": "Arándanos","Precio": 7000, "Cantidad": 1, "Unidad": "kg", "Precio Unitario": 7000}.to_json,
-          {"Nombre": "Leche","Precio": 400, "Cantidad": 1, "Unidad": "kg", "Precio Unitario": 400}.to_json] %>"
+          {"Nombre": "Manzana","Precio": 1000, "Cantidad": 1.5, "Unidad": "Kg", "Precio Unitario": 667}.to_json,
+          {"Nombre": "Arándanos","Precio": 7000, "Cantidad": 1, "Unidad": "Kg", "Precio Unitario": 7000}.to_json,
+          {"Nombre": "Leche","Precio": 400, "Cantidad": 1, "Unidad": "Litro", "Precio Unitario": 400}.to_json] %>"
       >
       </ingredients>
   </div>


### PR DESCRIPTION
Se hicieron algunos arreglos a la vista de ingredientes:

- Principalmente problemas del css cuando la página cambiaba de tamaño.
- Se agregaron al form de editar ingredientes los valores que tenía el ingrediente.

# QA

- Iniciar la aplicación e ir a `/ingredients`. Si se cambian los tamaños de la página (sobre todo achicando), la aplicación es hasta cierto punto responsiva (por lo menos no se ve nada raro ni componentes acopladas. Más adelante se espera hacerla más responsiva aún, pero esto es una base)
-  Al hacer click en el ícono de "tres puntos" para cualquier ingrediente, se abre el modal con el form para editar el ingrediente. En él se ven los valores que tenía el ingrediente. 
- En el form editar, el dropdown con la unidad queda seleccionado por defecto con la unidad que tenía el ingrediente y se muestran las demás opciones que se tienen de unidades (notar que no hay duplicados de unidades, por ejemplo si la unidad del ingrediente era Kg, y además se tienen litros, solo saldrán estas 2 opciones en el dropdown y Kg no estará dos veces solo por el hecho de ser la seleccionada). Además, entre las opciones no se encuentra "Unidad" (en el form de Agregar se tiene la opción "Unidad" pero que está `hidden` ya que cumple un rol de placeholder más que nada).

# Falta

- Aún no hay conexión con el backend
- Que sea más responsiva aún (pero esto por ahora no es prioridad)