### PR TITLE
Add vue i18n

### DIFF
--- a/app/javascript/components/base/base-modal-component.vue
+++ b/app/javascript/components/base/base-modal-component.vue
@@ -20,7 +20,7 @@
         class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform
        transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full"
       >
-        <!--Título-->
+        <!--Title-->
         <div class="bg-gray-900 px-6 py-6 sm:px-6 sm:flex sm:flex-row">
           <h3
             class="text-lg leading-6 font-medium text-white"
@@ -30,7 +30,7 @@
           </h3>
         </div>
 
-        <!--Contenido-->
+        <!--Content-->
         <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
           <div class="sm:flex sm:items-start">
             <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
@@ -41,7 +41,7 @@
           </div>
         </div>
 
-        <!--Botones-->
+        <!--Buttons-->
         <div class="bg-white px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
           <base-button
             :elements="{

--- a/app/javascript/components/base/base-search-component.vue
+++ b/app/javascript/components/base/base-search-component.vue
@@ -29,7 +29,6 @@
 <script>
 export default {
   props: {
-    kind: { type: String, required: true },
     placeholder: { type: String, required: true },
   },
 };

--- a/app/javascript/components/base/base-search-component.vue
+++ b/app/javascript/components/base/base-search-component.vue
@@ -18,7 +18,7 @@
           type="search"
           name="q"
           class="border-2 w-full border-yellow-700 py-2 text-sm text-yellow-700 pl-10 focus:outline-none focus:bg-white focus:text-yellow-700"
-          placeholder="Buscar ingrediente..."
+          :placeholder="placeholder"
           autocomplete="off"
         >
       </div>
@@ -29,7 +29,8 @@
 <script>
 export default {
   props: {
-    ingredient: { type: Object, required: true },
+    kind: { type: String, required: true },
+    placeholder: { type: String, required: true },
   },
 };
 </script>

--- a/app/javascript/components/base/base-table-component.vue
+++ b/app/javascript/components/base/base-table-component.vue
@@ -6,7 +6,7 @@
           v-for="attribute in header"
           :key="attribute"
         >
-          <span class="text-white font-bold">{{ $t(`msg.${attribute}`) }}</span>
+          <span class="text-white font-bold">{{ $t(`msg.${modelType}.${attribute}`) }}</span>
         </th>
         <th v-if="dots" />
       </tr>
@@ -51,6 +51,7 @@ export default {
     header: { type: Array, required: true },
     body: { type: Array, required: true },
     dots: { type: Boolean, required: true },
+    modelType: { type: String, required: true },
   },
   methods: {
     editIngredient(element) {

--- a/app/javascript/components/base/base-table-component.vue
+++ b/app/javascript/components/base/base-table-component.vue
@@ -3,10 +3,10 @@
     <thead class="justify-between">
       <tr class="bg-yellow-500 border-4 border-yellow-500 py-1">
         <th
-          v-for="attribute in table.header"
+          v-for="attribute in header"
           :key="attribute"
         >
-          <span class="text-white font-bold">{{ attribute }}</span>
+          <span class="text-white font-bold">{{ $t(`msg.${attribute}`) }}</span>
         </th>
         <th v-if="dots" />
       </tr>
@@ -14,11 +14,11 @@
     <tbody class="bg-gray-200">
       <tr
         v-for="parsedElement in parsedElements"
-        :key="parsedElement.Nombre"
+        :key="parsedElement.name"
         class="bg-white border-4 border-gray-200"
       >
         <td
-          v-for="property in table.header"
+          v-for="property in header"
           :key="property"
           class="content-center py-2"
         >
@@ -48,7 +48,8 @@
 
 export default {
   props: {
-    table: { type: Object, required: true },
+    header: { type: Array, required: true },
+    body: { type: Array, required: true },
     dots: { type: Boolean, required: true },
   },
   methods: {
@@ -62,7 +63,7 @@ export default {
 
   computed: {
     parsedElements() {
-      const parsedElements = this.table.body.map((element) => JSON.parse(element));
+      const parsedElements = this.body.map((element) => JSON.parse(element));
 
       return parsedElements;
     },

--- a/app/javascript/components/ingredients/base-component.vue
+++ b/app/javascript/components/ingredients/base-component.vue
@@ -9,7 +9,6 @@
     <!--SearchBar y Button-->
     <div class="flex items-center">
       <search
-        kind="ingredient"
         :placeholder="$t('msg.ingredients.search')"
       />
       <base-button

--- a/app/javascript/components/ingredients/base-component.vue
+++ b/app/javascript/components/ingredients/base-component.vue
@@ -25,6 +25,7 @@
         :dots="true"
         :header="tableHeader"
         :body="ingredients"
+        model-type="ingredients"
         @edit="toggleEditModal"
         @del="toggleDelModal"
       />

--- a/app/javascript/components/ingredients/base-component.vue
+++ b/app/javascript/components/ingredients/base-component.vue
@@ -3,16 +3,18 @@
   <div>
     <!--Title-->
     <h2 class="text-4xl">
-      Ingredientes
+      {{ $t('msg.ingredients.title') }}
     </h2>
 
     <!--SearchBar y Button-->
     <div class="flex items-center">
       <search
-        :ingredient="{ tipo: 'ingrediente' }"
+        kind="ingredient"
+        :placeholder="$t('msg.ingredients.search')"
       />
       <base-button
-        :elements="{ placeholder:'Agregar ingrediente', color: 'bg-green-500 hover:bg-green-700 text-white' }"
+        :elements="{ placeholder: $t('msg.ingredients.add'),
+                     color: 'bg-green-500 hover:bg-green-700 text-white' }"
         @click="toggleAddModal"
       />
     </div>
@@ -21,7 +23,8 @@
     <div class="flex items-center">
       <base-table
         :dots="true"
-        :table="{ header: tableHeader, body: ingredients }"
+        :header="tableHeader"
+        :body="ingredients"
         @edit="toggleEditModal"
         @del="toggleDelModal"
       />
@@ -32,9 +35,9 @@
       @ok="addIngredient"
       @cancel="toggleAddModal"
       v-if="showingAdd"
-      title="Agregar Ingrediente"
-      ok-button-label="Agregar"
-      cancel-button-label="Cancelar"
+      :title="$t('msg.ingredients.add')"
+      :ok-button-label="$t('msg.add')"
+      :cancel-button-label="$t('msg.cancel')"
     >
       <ingredients-form
         :units="['Kg','Litro']"
@@ -47,9 +50,9 @@
       @ok="editIngredient"
       @cancel="toggleEditModal"
       v-if="showingEdit"
-      title="Editar Ingrediente"
-      ok-button-label="Guardar"
-      cancel-button-label="Cancelar"
+      :title="$t('msg.ingredients.edit')"
+      :ok-button-label="$t('msg.save')"
+      :cancel-button-label="$t('msg.cancel')"
     >
       <ingredients-form
         :units="['Kg','Litro']"
@@ -63,11 +66,11 @@
       @ok="deleteIngredient"
       @cancel="toggleDelModal"
       v-if="showingDel"
-      title="Eliminar Ingrediente"
-      ok-button-label="Sí, Eliminar"
-      cancel-button-label="Cancelar"
+      :title="$t('msg.ingredients.delete')"
+      :ok-button-label="$t('msg.yesDelete')"
+      :cancel-button-label="$t('msg.cancel')"
     >
-      <p>Estás seguro que deseas eliminar este ingrediente?</p>
+      <p>{{ $t('msg.ingredients.deleteMsg') }}</p>
     </base-modal>
   </div>
 </template>
@@ -84,6 +87,7 @@ export default {
       showingEdit: false,
       showingDel: false,
       ingredientToEdit: {},
+      tableHeader: ['name', 'price', 'quantity', 'measure'],
     };
   },
   methods: {
@@ -105,13 +109,6 @@ export default {
     },
     deleteIngredient() {
       this.showingDel = !this.showingDel;
-    },
-  },
-  computed: {
-    tableHeader() {
-      const tableHeader = Object.keys(JSON.parse(this.ingredients[0]));
-
-      return tableHeader;
     },
   },
 };

--- a/app/javascript/components/ingredients/base-dropdown-component.vue
+++ b/app/javascript/components/ingredients/base-dropdown-component.vue
@@ -15,14 +15,14 @@
               class="font-semibold block px-4 py-3"
               v-if="elements.edit"
               @click="editIngredient"
-            >Editar</a>
+            >{{ $t('msg.edit') }}</a>
           </li>
           <li class="hover:bg-gray-100">
             <a
               class="font-semibold block px-4 py-3"
               v-if="elements.del"
               @click="deleteIngredient"
-            >Eliminar</a>
+            >{{ $t('msg.delete') }}</a>
           </li>
         </ul>
       </div>

--- a/app/javascript/components/ingredients/base-form-component.vue
+++ b/app/javascript/components/ingredients/base-form-component.vue
@@ -6,8 +6,8 @@
           <input-form
             id="ingredient-name"
             type="text"
-            placeholder="Nombre"
-            :value="editMode ? ingredient.Nombre : ''"
+            :placeholder="$t('msg.ingredients.name')"
+            :value="editMode ? ingredient.name : ''"
           />
         </div>
       </div>
@@ -17,8 +17,8 @@
           <input-form
             id="ingredient-amount"
             type="number"
-            placeholder="Cantidad"
-            :value="editMode ? ingredient.Cantidad : ''"
+            :placeholder="$t('msg.ingredients.quantity')"
+            :value="editMode ? ingredient.quantity : ''"
           />
         </div>
         <div class="relative">
@@ -33,16 +33,16 @@
               hidden
               selected
             >
-              Unidad
+              {{ $t('msg.ingredients.measure') }}
             </option>
             <!--Edit Mode unit ingredient -->
             <option
               v-if="editMode"
               selected
-              :key="ingredient.Unidad"
-              :value="ingredient.Unidad"
+              :key="ingredient.measure"
+              :value="ingredient.measure"
             >
-              {{ ingredient.Unidad }}
+              {{ ingredient.measure }}
             </option>
             <!--Other units -->
             <option
@@ -69,8 +69,8 @@
           <input-form
             id="ingredient-price"
             type="number"
-            placeholder="Precio"
-            :value="editMode? ingredient.Precio : ''"
+            :placeholder="$t('msg.ingredients.price')"
+            :value="editMode? ingredient.price : ''"
           />
         </div>
       </div>
@@ -95,7 +95,7 @@ export default {
         return this.units;
       }
 
-      return this.units.filter(unit => unit !== this.ingredient.Unidad);
+      return this.units.filter(unit => unit !== this.ingredient.measure);
     },
   },
 };

--- a/app/javascript/components/layout/side-navbar-component.vue
+++ b/app/javascript/components/layout/side-navbar-component.vue
@@ -2,8 +2,8 @@
   <div class="flex flex-col items-start pt-0 pl-0 pr-0 pb-8 absolute w-64 h-screen left-0 top-16 bg-gray-800">
     <a href="/ingredients">
       <item
-        label="Ingredientes"
-        :active="activeElement==='Ingredientes'"
+        :label="$t('msg.ingredients.title')"
+        :active="activeElement==='ingredients'"
       >
         <img
           class="h-5 w-5 text-white"
@@ -15,8 +15,8 @@
 
     <a href="/recipes">
       <item
-        label="Recetas"
-        :active="activeElement==='Recetas'"
+        :label="$t('msg.recipes.title')"
+        :active="activeElement==='recipes'"
       >
         <img
           class="h-5 w-5 text-white"
@@ -28,8 +28,8 @@
 
     <a href="/menus">
       <item
-        label="Menús"
-        :active="activeElement==='Menus'"
+        :label="$t('msg.menus.title')"
+        :active="activeElement==='menus'"
       >
         <img
           class="h-5 w-5 text-white"

--- a/app/javascript/components/layout/top-navbar-component.vue
+++ b/app/javascript/components/layout/top-navbar-component.vue
@@ -7,7 +7,7 @@
             <a
               href="/"
               class="text-white px-3 py-2 rounded-md text-lg font-bold"
-            >SuperKitchen</a>
+            >KitchenGram</a>
           </div>
         </div>
       </div>

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -3,7 +3,7 @@ export default {
     add: 'Agregar',
     edit: 'Editar',
     delete: 'Eliminar',
-    yesDelete: 'Sí,Eliminar',
+    yesDelete: 'Sí, Eliminar',
     save: 'Guardar',
     cancel: 'Cancelar',
     name: 'Nombre',

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -1,0 +1,41 @@
+export default {
+  msg: {
+    add: 'Agregar',
+    edit: 'Editar',
+    delete: 'Eliminar',
+    yesDelete: 'Sí,Eliminar',
+    save: 'Guardar',
+    cancel: 'Cancelar',
+    name: 'Nombre',
+    price: 'Precio',
+    quantity: 'Cantidad',
+    measure: 'Unidad',
+
+    ingredients: {
+      title: 'Ingredientes',
+      search: 'Buscar ingrediente...',
+      add: 'Agregar ingrediente',
+      edit: 'Editar ingrediente',
+      delete: 'Eliminar ingrediente',
+      deleteMsg: 'Estás seguro de que deseas eliminar este ingrediente?',
+    },
+
+    recipes: {
+      title: 'Recetas',
+      search: 'Buscar receta',
+      add: 'Agregar receta',
+      edit: 'Editar receta',
+      delete: 'Eliminar receta',
+      deleteMsg: 'Estás seguro de que deseas eliminar esta receta?',
+    },
+
+    menus: {
+      title: 'Menús',
+      search: 'Buscar menú',
+      add: 'Agregar menú',
+      edit: 'Editar menú',
+      delete: 'Eliminar menú',
+      deleteMsg: 'Estás seguro de que deseas eliminar este menú?',
+    },
+  },
+};

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -6,10 +6,6 @@ export default {
     yesDelete: 'Sí, Eliminar',
     save: 'Guardar',
     cancel: 'Cancelar',
-    name: 'Nombre',
-    price: 'Precio',
-    quantity: 'Cantidad',
-    measure: 'Unidad',
 
     ingredients: {
       title: 'Ingredientes',
@@ -18,6 +14,10 @@ export default {
       edit: 'Editar ingrediente',
       delete: 'Eliminar ingrediente',
       deleteMsg: 'Estás seguro de que deseas eliminar este ingrediente?',
+      name: 'Nombre',
+      price: 'Precio',
+      quantity: 'Cantidad',
+      measure: 'Unidad',
     },
 
     recipes: {

--- a/app/javascript/locales/locales.js
+++ b/app/javascript/locales/locales.js
@@ -1,0 +1,7 @@
+import esLocale from './es';
+
+const messages = {
+  es: esLocale,
+};
+
+export default { messages };

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,4 +1,5 @@
 import Vue from 'vue/dist/vue.esm';
+import VueI18n from 'vue-i18n';
 import '../css/application.css';
 
 import TopNavbar from '../components/layout/top-navbar-component.vue';
@@ -12,6 +13,10 @@ import Search from '../components/base/base-search-component.vue';
 import BaseTable from '../components/base/base-table-component.vue';
 import BaseModal from '../components/base/base-modal-component.vue';
 import IngredientsForm from '../components/ingredients/base-form-component';
+
+import Locales from '../locales/locales.js';
+
+Vue.use(VueI18n);
 
 Vue.component('TopNavbar', TopNavbar);
 Vue.component('SideNavbar', SideNavbar);
@@ -28,6 +33,10 @@ Vue.component('IngredientsForm', IngredientsForm);
 document.addEventListener('DOMContentLoaded', () => {
   const app = new Vue({
     el: '#vue-app',
+    i18n: new VueI18n({
+      locale: 'es',
+      messages: Locales.messages,
+    }),
   });
 
   return app;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -2,6 +2,8 @@ import Vue from 'vue/dist/vue.esm';
 import VueI18n from 'vue-i18n';
 import '../css/application.css';
 
+import Locales from '../locales/locales.js';
+
 import TopNavbar from '../components/layout/top-navbar-component.vue';
 import SideNavbar from '../components/layout/side-navbar-component.vue';
 import Ingredients from '../components/ingredients/base-component.vue';
@@ -13,8 +15,6 @@ import Search from '../components/base/base-search-component.vue';
 import BaseTable from '../components/base/base-table-component.vue';
 import BaseModal from '../components/base/base-modal-component.vue';
 import IngredientsForm from '../components/ingredients/base-form-component';
-
-import Locales from '../locales/locales.js';
 
 Vue.use(VueI18n);
 

--- a/app/views/ingredients/index.html.erb
+++ b/app/views/ingredients/index.html.erb
@@ -1,11 +1,11 @@
 <div class="h-screen flex">
-  <side-navbar active-element = "Ingredientes"></side-navbar>
+  <side-navbar active-element="ingredients"></side-navbar>
   <div class="container ml-64 px-20 py-10 overflow-hidden">
       <ingredients
         :ingredients="<%= [
-          {"Nombre": "Manzana","Precio": 1000, "Cantidad": 1.5, "Unidad": "Kg", "Precio Unitario": 667}.to_json,
-          {"Nombre": "Arándanos","Precio": 7000, "Cantidad": 1, "Unidad": "Kg", "Precio Unitario": 7000}.to_json,
-          {"Nombre": "Leche","Precio": 400, "Cantidad": 1, "Unidad": "Litro", "Precio Unitario": 400}.to_json] %>"
+          {"name": "Manzana","price": 1000, "quantity": 1.5, "measure": "Kg"}.to_json,
+          {"name": "Arándanos","price": 7000, "quantity": 1, "measure": "Kg"}.to_json,
+          {"name": "Leche","price": 400, "quantity": 1, "measure": "Litro"}.to_json] %>"
       >
       </ingredients>
   </div>

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -1,4 +1,6 @@
-<side-navbar active-element = "Menus"></side-navbar>
-<div class="container mx-auto px-60 py-10">
-    Menus
+<div class="h-screen flex">
+  <side-navbar active-element="menus"></side-navbar>
+  <div class="container ml-64 px-20 py-10 overflow-hidden">
+      Menus
+  </div>
 </div>

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -1,6 +1,5 @@
 <div class="h-screen flex">
   <side-navbar active-element="menus"></side-navbar>
   <div class="container ml-64 px-20 py-10 overflow-hidden">
-      Menus
   </div>
 </div>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -1,6 +1,5 @@
 <div class="h-screen flex">
   <side-navbar active-element="recipes"></side-navbar>
   <div class="container ml-64 px-20 py-10 overflow-hidden">
-      Recetas
   </div>
 </div>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -1,4 +1,6 @@
-<side-navbar active-element = "Recetas"></side-navbar>
-<div class="container mx-auto px-60 py-10">
-    Recetas
+<div class="h-screen flex">
+  <side-navbar active-element="recipes"></side-navbar>
+  <div class="container ml-64 px-20 py-10 overflow-hidden">
+      Recetas
+  </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.0",
     "turbolinks": "^5.2.0",
     "vue": "^2.6.12",
+    "vue-i18n": "^8.24.4",
     "vue-loader": "^15.9.6",
     "vue-template-compiler": "^2.6.12"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10731,6 +10731,11 @@ vue-hot-reload-api@^2.3.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz"
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
 
+vue-i18n@^8.24.4:
+  version "8.24.4"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-8.24.4.tgz#b158614c1df7db183d9cadddbb73e1d540269492"
+  integrity sha512-RZE94WUAGxEiBAANxQ0pptbRwDkNKNSXl3fnJslpFOxVMF6UkUtMDSuYGuW2blDrVgweIXVpethOVkYoNNT9xw==
+
 vue-jest@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/vue-jest/-/vue-jest-3.0.7.tgz"


### PR DESCRIPTION
Se agregó i18n a la aplicación para poder manejar los textos de mejor forma y eventualmente poder traducir a otros idiomas. 

# QA
- Correr la app, e ir a `/ingredients`, la vista se debería mostrar normal, los nombres en español, pero considerando que en el código se manejan por detrás con i18n. 

# Falta
- Conexión con el backend así que aún se pasan los datos como props.