### PR TITLE
feat(api@products-scraper): add separated endpoints for scrapers

### DIFF
--- a/app/clients/jumbo_client.rb
+++ b/app/clients/jumbo_client.rb
@@ -6,13 +6,16 @@ class JumboClient < MarketClient
 
   def products_found_to_json
     products_found.map do |product|
+      price = get_price(product) || get_old_price(product) || get_offer_price(product)
+      next if price.blank?
+
       {
-        price: get_price(product) || get_old_price(product) || get_offer_price(product),
+        price: price,
         measure: get_measure(product),
         name: get_name(product),
         provider: MARKET_NAME
       }
-    end
+    end.compact
   end
 
   def products_found
@@ -30,8 +33,10 @@ class JumboClient < MarketClient
   end
 
   def get_offer_price(product)
-    price = product.search('.price-product-best').first.text
-    format_search(price)
+    price = product.search('.price-product-best').first
+    return if price.blank?
+
+    format_search(price.text)
   end
 
   def get_measure(product)

--- a/app/controllers/api/v1/ingredients_controller.rb
+++ b/app/controllers/api/v1/ingredients_controller.rb
@@ -1,13 +1,16 @@
 class Api::V1::IngredientsController < Api::V1::BaseController
   acts_as_token_authentication_handler_for User, fallback: :exception
 
-  def search_ingredients
-    base_result = []
-    clients.each do |client|
-      base_result += client.new.products_by_query(query: search_params[:query])
-    end
+  def search_jumbo_ingredients
+    result = JumboClient.new.products_by_query(query: search_params[:query])
 
-    respond_with({ data: base_result })
+    respond_with({ data: result })
+  end
+
+  def search_lider_ingredients
+    result = LiderClient.new.products_by_query(query: search_params[:query])
+
+    respond_with({ data: result })
   end
 
   def index
@@ -31,10 +34,6 @@ class Api::V1::IngredientsController < Api::V1::BaseController
   end
 
   private
-
-  def clients
-    [JumboClient]
-  end
 
   def search_params
     params.permit(:query)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,8 +10,9 @@ Rails.application.routes.draw do
         end
       end
 
-      # Ingredients
-      get '/search-ingredients', to: 'ingredients#search_ingredients'
+      # Ingredients by scraper
+      get '/search-jumbo-ingredients', to: 'ingredients#search_jumbo_ingredients'
+      get '/search-lider-ingredients', to: 'ingredients#search_lider_ingredients'
     end
   end
 

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -285,7 +285,7 @@
     }
   },
   "paths": {
-    "/search-ingredients": {
+    "/search-jumbo-ingredients": {
       "parameters": [
         {
           "name": "user_email",
@@ -311,7 +311,58 @@
         "produces": [
           "application/json"
         ],
-        "description": "Retrieves ingredients by different providers",
+        "description": "Retrieves ingredients from Jumbo",
+        "responses": {
+          "200": {
+            "description": "ingredients retrieved",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/provider_ingredient"
+                  }
+                }
+              },
+              "required": [
+                "data"
+              ]
+            }
+          },
+          "401": {
+            "description": "user unauthorized"
+          }
+        }
+      }
+    },
+    "/search-lider-ingredients": {
+      "parameters": [
+        {
+          "name": "user_email",
+          "in": "query",
+          "type": "string"
+        },
+        {
+          "name": "user_token",
+          "in": "query",
+          "type": "string"
+        },
+        {
+          "name": "query",
+          "in": "query",
+          "type": "string"
+        }
+      ],
+      "get": {
+        "summary": "Search ingredients",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "description": "Retrieves ingredients from Lider",
         "responses": {
           "200": {
             "description": "ingredients retrieved",


### PR DESCRIPTION
Base #31

### Contexto

Antes había pensado el endpoint de buscar productos en un supermercado como uno que busque por todos los clientes y entregue un array completo con productos y su proveedor, pero cada uno está demorando harto y puede tirar timeout. Mejor hacerlos por separado y que en frontend hagan cada consulta.

Pensé tb en crear un puro endpoint donde le dices el provider y se hace el mapeo por atrás, pero no sé si sea tan buena idea

### Lo que hice

Creé dos endpoints que utilizan los clientes creados para retornar una lista estándar de productos.
![image](https://user-images.githubusercontent.com/30879716/116825377-148c9d80-ab5d-11eb-8c98-f8f2a019c81a.png)


### QA

Entrar a `/api-docs` y probar la API para jumbo y lider, con cualquier query.