### PR TITLE
BASE[#39] feat(models/recipe): remove instructions because of new model

### DIFF
--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -35,7 +35,6 @@ class Api::V1::RecipesController < Api::V1::BaseController
     params.require(:recipe).permit(
       :name,
       :portions,
-      :instructions,
       :cook_minutes
     )
   end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -15,7 +15,6 @@ end
 #  user_id      :bigint(8)        not null
 #  name         :string
 #  portions     :integer
-#  instructions :text
 #  cook_minutes :integer
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null

--- a/app/serializers/api/v1/recipe_serializer.rb
+++ b/app/serializers/api/v1/recipe_serializer.rb
@@ -8,7 +8,7 @@ class Api::V1::RecipeSerializer < ActiveModel::Serializer
     :cook_minutes,
     :created_at,
     :updated_at,
-    :ingredients
+    :ingredients,
     :steps
   )
 end

--- a/app/serializers/api/v1/recipe_serializer.rb
+++ b/app/serializers/api/v1/recipe_serializer.rb
@@ -11,8 +11,4 @@ class Api::V1::RecipeSerializer < ActiveModel::Serializer
     :ingredients
     :steps
   )
-
-  def steps
-    object.steps.order(:number)
-  end
 end

--- a/app/serializers/api/v1/recipe_serializer.rb
+++ b/app/serializers/api/v1/recipe_serializer.rb
@@ -5,10 +5,14 @@ class Api::V1::RecipeSerializer < ActiveModel::Serializer
     :user_id,
     :name,
     :portions,
-    :instructions,
     :cook_minutes,
     :created_at,
     :updated_at,
     :ingredients
+    :steps
   )
+
+  def steps
+    object.steps.order(:number)
+  end
 end

--- a/db/migrate/20210507041420_drop_instructions_column_of_recipes.rb
+++ b/db/migrate/20210507041420_drop_instructions_column_of_recipes.rb
@@ -1,0 +1,5 @@
+class DropInstructionsColumnOfRecipes < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured { remove_column :recipes, :instructions, :text }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_07_003416) do
+ActiveRecord::Schema.define(version: 2021_05_07_041420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,7 +106,6 @@ ActiveRecord::Schema.define(version: 2021_05_07_003416) do
     t.bigint "user_id", null: false
     t.string "name"
     t.integer "portions"
-    t.text "instructions"
     t.integer "cook_minutes"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/seeds/recipes.rb
+++ b/db/seeds/recipes.rb
@@ -6,8 +6,6 @@ Recipe.create(
   user_id: user_1.id,
   name: 'Panqueques',
   portions: 8,
-  instructions: 'Junta todos los ingredientes hasta conseguir un atido homogéneo, 
-  luego vaya vertiendo porciones en un sartén. Finalmente, añada manjar',
   cook_minutes: 30
 )
 
@@ -15,6 +13,5 @@ Recipe.create(
   user_id: user_2.id,
   name: 'Pie de limón',
   portions: 10,
-  instructions: 'Las instrucciones para hacer pie de limón son las siguientes...',
   cook_minutes: 45
 )

--- a/spec/factories/recipes.rb
+++ b/spec/factories/recipes.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :recipe do
     name { Faker::Food.dish }
     portions { rand(1..6) }
-    instructions { Faker::Lorem.paragraph(sentence_count: 10) }
     cook_minutes { rand(10..180) }
     user { create(:user) }
   end

--- a/spec/integration/api/v1/recipes_spec.rb
+++ b/spec/integration/api/v1/recipes_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
-describe 'API::V1::Recipes', swagger_doc: 'v1/swagger.json' do
+# rubocop:disable RSpec/EmptyExampleGroup, RSpec/MultipleMemoizedHelpers
+describe 'Api::V1::Recipes', swagger_doc: 'v1/swagger.json' do
   let!(:user) { create(:user) }
   let(:user_email) { user.email }
   let(:user_token) { user.authentication_token }
@@ -58,7 +59,6 @@ describe 'API::V1::Recipes', swagger_doc: 'v1/swagger.json' do
             user_id: new_recipe.id,
             name: new_recipe.name,
             portions: new_recipe.portions,
-            instructions: new_recipe.instructions,
             cook_minutes: new_recipe.cook_minutes
           }
         end
@@ -126,7 +126,6 @@ describe 'API::V1::Recipes', swagger_doc: 'v1/swagger.json' do
             user_id: user.id,
             name: 'Some name',
             portions: 666,
-            instructions: 'Some instructions',
             cook_minutes: 666
           }
         end
@@ -164,3 +163,4 @@ describe 'API::V1::Recipes', swagger_doc: 'v1/swagger.json' do
     end
   end
 end
+# rubocop:enable RSpec/EmptyExampleGroup, RSpec/MultipleMemoizedHelpers

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Recipe, type: :model do
   it { is_expected.to have_many(:ingredients).through(:recipe_ingredients) }
 
   describe 'it has all the attributes' do
-    ["name", "portions", "instructions", "cook_minutes"].each do |attribute|
+    ["name", "portions", "cook_minutes"].each do |attribute|
       it "includes the #{attribute} attribute" do
         expect(recipe.attributes).to include(attribute)
       end

--- a/spec/swagger/v1/schemas/recipe_schema.rb
+++ b/spec/swagger/v1/schemas/recipe_schema.rb
@@ -3,13 +3,11 @@ RECIPE_SCHEMA = {
   properties: {
     name: { type: :string, example: 'Pastel de choclo', 'x-nullable': true },
     portions: { type: :integer, example: 4, 'x-nullable': true },
-    instructions: { type: :string, example: 'Some instructions', 'x-nullable': true },
     cook_minutes: { type: :integer, example: 25, 'x-nullable': true }
   },
   required: [
     :name,
     :portions,
-    :instructions,
     :cook_minutes
   ]
 }
@@ -25,7 +23,6 @@ RECIPE_RESPONSE_SCHEMA = {
         user_id: { type: :integer, example: 1, 'x-nullable': true },
         name: { type: :string, example: 'Pastel de choclo', 'x-nullable': true },
         portions: { type: :integer, example: 4, 'x-nullable': true },
-        instructions: { type: :string, example: 'Some instructions', 'x-nullable': true },
         cook_minutes: { type: :integer, example: 25, 'x-nullable': true },
         created_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
         updated_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },


### PR DESCRIPTION
BASE #39

### Contexto

El contexto está en el PR #39. TLDR: Usamos el modelo `RecipeSteps` en vez de el atributo `instructions` para manejar los pasos de la receta.

### Lo que hice

Eliminé entonces instructions de la BD, ahora usamos el nuevo modelo :)