### PR TITLE
BASE[#40] feat(recipe-steps): add recipe steps to api

### DIFF
--- a/app/controllers/api/v1/recipe_steps_controller.rb
+++ b/app/controllers/api/v1/recipe_steps_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::RecipeStepsController < Api::V1::BaseController
   private
 
   def recipe_step
-    @recipe_step ||= RecipeStep.find_by!(id: params[:id])
+    @recipe_step ||= recipe_steps.find_by!(id: params[:id])
   end
 
   def recipe_steps

--- a/app/controllers/api/v1/recipe_steps_controller.rb
+++ b/app/controllers/api/v1/recipe_steps_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::RecipeStepsController < Api::V1::BaseController
 
   def recipe_step_params
     params.require(:recipe_step).permit(
-      :number,
+      :step_order_position,
       :description,
       :media_url,
       :recipe_id

--- a/app/controllers/api/v1/recipe_steps_controller.rb
+++ b/app/controllers/api/v1/recipe_steps_controller.rb
@@ -1,0 +1,42 @@
+class Api::V1::RecipeStepsController < Api::V1::BaseController
+  acts_as_token_authentication_handler_for User, fallback: :exception
+
+  def create
+    respond_with recipe_steps.create!(recipe_step_params)
+  end
+
+  def update
+    respond_with recipe_step.update!(recipe_step_params)
+  end
+
+  def destroy
+    respond_with recipe_step.destroy!
+  end
+
+  private
+
+  def recipe_step
+    @recipe_step ||= RecipeStep.find_by!(id: params[:id])
+  end
+
+  def recipe_steps
+    @recipe_steps ||= recipe.steps
+  end
+
+  def recipe
+    @recipe ||= recipes.find_by!(id: params[:recipe_id])
+  end
+
+  def recipes
+    @recipes ||= current_user.recipes
+  end
+
+  def recipe_step_params
+    params.require(:recipe_step).permit(
+      :number,
+      :description,
+      :media_url,
+      :recipe_id
+    )
+  end
+end

--- a/app/serializers/api/v1/recipe_serializer.rb
+++ b/app/serializers/api/v1/recipe_serializer.rb
@@ -11,4 +11,8 @@ class Api::V1::RecipeSerializer < ActiveModel::Serializer
     :ingredients,
     :steps
   )
+
+  def steps
+    object.steps.order(:number)
+  end
 end

--- a/app/serializers/api/v1/recipe_serializer.rb
+++ b/app/serializers/api/v1/recipe_serializer.rb
@@ -13,6 +13,7 @@ class Api::V1::RecipeSerializer < ActiveModel::Serializer
   )
 
   def steps
-    object.steps.order(:number)
+    ActiveModelSerializers::SerializableResource.new(object.steps.rank(:step_order),
+                                                     each_serializer: Api::V1::RecipeStepSerializer)
   end
 end

--- a/app/serializers/api/v1/recipe_step_serializer.rb
+++ b/app/serializers/api/v1/recipe_step_serializer.rb
@@ -1,0 +1,12 @@
+class Api::V1::RecipeStepSerializer < ActiveModel::Serializer
+  type :recipe_step
+
+  attributes(
+    :number,
+    :description,
+    :media_url,
+    :recipe_id,
+    :created_at,
+    :updated_at
+  )
+end

--- a/app/serializers/api/v1/recipe_step_serializer.rb
+++ b/app/serializers/api/v1/recipe_step_serializer.rb
@@ -2,7 +2,7 @@ class Api::V1::RecipeStepSerializer < ActiveModel::Serializer
   type :recipe_step
 
   attributes(
-    :number,
+    :step_order_rank,
     :description,
     :media_url,
     :recipe_id,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root to: 'home#index'
   scope path: '/api' do
     api_version(module: 'Api::V1', path: { value: 'v1' }, defaults: { format: 'json' }) do
+      resources :recipe_steps, only: [:update, :destroy]
       resources :ingredients
       resources :providers
       resources :menus

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     api_version(module: 'Api::V1', path: { value: 'v1' }, defaults: { format: 'json' }) do
       resources :ingredients
       resources :providers
+      resources :menus
       resources :recipes do
         resources :recipe_steps, only: [:create, :update, :destroy]
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,11 +2,12 @@ Rails.application.routes.draw do
   root to: 'home#index'
   scope path: '/api' do
     api_version(module: 'Api::V1', path: { value: 'v1' }, defaults: { format: 'json' }) do
-      resources :recipe_steps, only: [:update, :destroy]
       resources :ingredients
       resources :providers
-      resources :menus
-      resources :recipes
+      resources :recipes do
+        resources :recipe_steps, only: [:create, :update, :destroy]
+      end
+
       namespace :users do
         devise_scope :user do
           resources :registrations, only: [:create]

--- a/spec/integration/api/v1/recipe_steps_spec.rb
+++ b/spec/integration/api/v1/recipe_steps_spec.rb
@@ -82,7 +82,7 @@ describe 'Api::V1::RecipeSteps', swagger_doc: 'v1/swagger.json' do
       response '200', 'recipe_step updated' do
         let(:recipe_step) do
           {
-            number: 1,
+            step_order_position: 1,
             description: 'Some description'
           }
         end

--- a/spec/integration/api/v1/recipe_steps_spec.rb
+++ b/spec/integration/api/v1/recipe_steps_spec.rb
@@ -51,7 +51,8 @@ describe 'Api::V1::RecipeSteps', swagger_doc: 'v1/swagger.json' do
     end
   end
 
-  path '/recipe_steps/{id}' do
+  path '/recipes/{recipe_id}/recipe_steps/{id}' do
+    parameter name: :recipe_id, in: :path, type: :integer
     parameter name: :user_email, in: :query, type: :string
     parameter name: :user_token, in: :query, type: :string
 

--- a/spec/integration/api/v1/recipe_steps_spec.rb
+++ b/spec/integration/api/v1/recipe_steps_spec.rb
@@ -1,0 +1,122 @@
+require 'swagger_helper'
+
+# rubocop:disable RSpec/EmptyExampleGroup, RSpec/MultipleMemoizedHelpers
+describe 'Api::V1::RecipeSteps', swagger_doc: 'v1/swagger.json' do
+  let(:user) { create(:user) }
+  let(:user_email) { user.email }
+  let(:user_token) { user.authentication_token }
+
+  let!(:recipe) { create(:recipe, user: user) }
+  let(:recipe_id) { recipe.id }
+
+  path '/recipes/{recipe_id}/recipe_steps' do
+    parameter name: :recipe_id, in: :path, type: :integer
+    parameter name: :user_email, in: :query, type: :string
+    parameter name: :user_token, in: :query, type: :string
+
+    post 'Creates Recipe Step' do
+      description 'Creates Recipe Step'
+      consumes 'application/json'
+      produces 'application/json'
+      parameter(
+        name: :recipe_step,
+        in: :body,
+        schema: {
+          type: "object",
+          properties: {
+            recipe_step: { "$ref" => "#/definitions/recipe_step" }
+          },
+          required: [
+            :recipe_step
+          ]
+        }
+      )
+
+      response '201', 'recipe_step created' do
+        let(:recipe_step) do
+          {
+            description: 'Some description'
+          }
+        end
+
+        run_test!
+      end
+
+      response '401', 'user unauthorized' do
+        let(:recipe_step) { {} }
+        let(:user_token) { 'invalid' }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/recipe_steps/{id}' do
+    parameter name: :user_email, in: :query, type: :string
+    parameter name: :user_token, in: :query, type: :string
+
+    parameter name: :id, in: :path, type: :integer
+
+    let(:existent_recipe_step) { create(:recipe_step, recipe: recipe) }
+    let(:id) { existent_recipe_step.id }
+
+    put 'Updates Recipe Step' do
+      description 'Updates Recipe Step'
+      consumes 'application/json'
+      produces 'application/json'
+      parameter(
+        name: :recipe_step,
+        in: :body,
+        schema: {
+          type: "object",
+          properties: {
+            recipe_step: { "$ref" => "#/definitions/recipe_step_update" }
+          },
+          required: [
+            :recipe_step
+          ]
+        }
+      )
+
+      response '200', 'recipe_step updated' do
+        let(:recipe_step) do
+          {
+            number: 1,
+            description: 'Some description'
+          }
+        end
+
+        run_test!
+      end
+
+      response '401', 'user unauthorized' do
+        let(:recipe_step) { {} }
+        let(:user_token) { 'invalid' }
+
+        run_test!
+      end
+    end
+
+    delete 'Deletes Recipe Step' do
+      produces 'application/json'
+      description 'Deletes specific recipe_step'
+
+      response '204', 'recipe_step deleted' do
+        run_test!
+      end
+
+      response '404', 'recipe_step not found' do
+        let(:id) { 'invalid' }
+
+        run_test!
+      end
+
+      response '401', 'user unauthorized' do
+        let(:user_token) { 'invalid' }
+
+        run_test!
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/EmptyExampleGroup, RSpec/MultipleMemoizedHelpers

--- a/spec/swagger/v1/definition.rb
+++ b/spec/swagger/v1/definition.rb
@@ -6,6 +6,11 @@ API_V1 = {
   },
   basePath: '/api/v1',
   definitions: {
+    recipe_step_update: RECIPE_STEP_UPDATE_SCHEMA,
+    recipe_step_response: RECIPE_STEP_RESPONSE_SCHEMA,
+    recipe_step: RECIPE_STEP_SCHEMA,
+    recipe_steps_collection: RECIPE_STEPS_COLLECTION_SCHEMA,
+    recipe_step_resource: RECIPE_STEP_RESOURCE_SCHEMA,
     user: USER_SCHEMA,
     provider_ingredient: PROVIDER_INGREDIENT_SCHEMA,
     ingredient: INGREDIENT_SCHEMA,

--- a/spec/swagger/v1/schemas/recipe_schema.rb
+++ b/spec/swagger/v1/schemas/recipe_schema.rb
@@ -31,8 +31,13 @@ RECIPE_RESPONSE_SCHEMA = {
           items: { "$ref" => "#/definitions/ingredient_response" }
         },
         steps: {
-          type: "array",
-          items: { "$ref" => "#/definitions/recipe_step_response" }
+          type: "object",
+          properties: {
+            data: {
+              type: "array",
+              items: { "$ref" => "#/definitions/recipe_step_response" }
+            }
+          }
         }
       },
       required: []

--- a/spec/swagger/v1/schemas/recipe_schema.rb
+++ b/spec/swagger/v1/schemas/recipe_schema.rb
@@ -29,6 +29,10 @@ RECIPE_RESPONSE_SCHEMA = {
         ingredients: {
           type: "array",
           items: { "$ref" => "#/definitions/ingredient_response" }
+        },
+        steps: {
+          type: "array",
+          items: { "$ref" => "#/definitions/recipe_step_response" }
         }
       },
       required: []

--- a/spec/swagger/v1/schemas/recipe_schema.rb
+++ b/spec/swagger/v1/schemas/recipe_schema.rb
@@ -16,7 +16,7 @@ RECIPE_RESPONSE_SCHEMA = {
   type: :object,
   properties: {
     id: { type: :string, example: '1' },
-    type: { type: :string, example: 'ingredient' },
+    type: { type: :string, example: 'recipe' },
     attributes: {
       type: :object,
       properties: {

--- a/spec/swagger/v1/schemas/recipe_step_schema.rb
+++ b/spec/swagger/v1/schemas/recipe_step_schema.rb
@@ -8,7 +8,7 @@ RECIPE_STEP_SCHEMA = {
 RECIPE_STEP_UPDATE_SCHEMA = {
   type: :object,
   properties: {
-    number: { type: :integer, example: 2, 'x-nullable': false },
+    step_order_position: { type: :integer, example: 2, 'x-nullable': false },
     description: { type: :string, example: 'Prender el horno', 'x-nullable': true }
   }
 }
@@ -21,7 +21,7 @@ RECIPE_STEP_RESPONSE_SCHEMA = {
     attributes: {
       type: :object,
       properties: {
-        number: { type: :integer, example: 1, 'x-nullable': true },
+        step_order_rank: { type: :integer, example: 0, 'x-nullable': true },
         description: { type: :string, example: 'Prender el horno', 'x-nullable': true },
         media_url: { type: :string, example: 'https://some-media-url.com', 'x-nullable': true },
         recipe_id: { type: :integer, example: 1, 'x-nullable': true },

--- a/spec/swagger/v1/schemas/recipe_step_schema.rb
+++ b/spec/swagger/v1/schemas/recipe_step_schema.rb
@@ -1,0 +1,62 @@
+RECIPE_STEP_SCHEMA = {
+  type: :object,
+  properties: {
+    description: { type: :string, example: 'Prender el horno', 'x-nullable': true }
+  }
+}
+
+RECIPE_STEP_UPDATE_SCHEMA = {
+  type: :object,
+  properties: {
+    number: { type: :integer, example: 2, 'x-nullable': false },
+    description: { type: :string, example: 'Prender el horno', 'x-nullable': true }
+  }
+}
+
+RECIPE_STEP_RESPONSE_SCHEMA = {
+  type: :object,
+  properties: {
+    id: { type: :string, example: '1' },
+    type: { type: :string, example: 'recipe_step' },
+    attributes: {
+      type: :object,
+      properties: {
+        number: { type: :integer, example: 1, 'x-nullable': true },
+        description: { type: :string, example: 'Prender el horno', 'x-nullable': true },
+        media_url: { type: :string, example: 'https://some-media-url.com', 'x-nullable': true },
+        recipe_id: { type: :integer, example: 1, 'x-nullable': true },
+        created_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
+        updated_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true }
+      },
+      required: []
+    }
+  },
+  required: [
+    :id,
+    :type,
+    :attributes
+  ]
+}
+
+RECIPE_STEPS_COLLECTION_SCHEMA = {
+  type: "object",
+  properties: {
+    data: {
+      type: "array",
+      items: { "$ref" => "#/definitions/recipe_step_response" }
+    }
+  },
+  required: [
+    :data
+  ]
+}
+
+RECIPE_STEP_RESOURCE_SCHEMA = {
+  type: "object",
+  properties: {
+    data: { "$ref" => "#/definitions/recipe_step_response" }
+  },
+  required: [
+    :data
+  ]
+}

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -9,7 +9,7 @@
     "recipe_step_update": {
       "type": "object",
       "properties": {
-        "number": {
+        "step_order_position": {
           "type": "integer",
           "example": 2,
           "x-nullable": false
@@ -35,9 +35,9 @@
         "attributes": {
           "type": "object",
           "properties": {
-            "number": {
+            "step_order_rank": {
               "type": "integer",
-              "example": 1,
+              "example": 0,
               "x-nullable": true
             },
             "description": {
@@ -566,9 +566,14 @@
               }
             },
             "steps": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/recipe_step_response"
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/recipe_step_response"
+                  }
+                }
               }
             }
           },

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -66,9 +66,7 @@
               "x-nullable": true
             }
           },
-          "required": [
-
-          ]
+          "required": []
         }
       },
       "required": [
@@ -255,9 +253,7 @@
               "x-nullable": true
             }
           },
-          "required": [
-
-          ]
+          "required": []
         }
       },
       "required": [
@@ -356,9 +352,7 @@
               "x-nullable": true
             }
           },
-          "required": [
-
-          ]
+          "required": []
         }
       },
       "required": [
@@ -578,9 +572,7 @@
               }
             }
           },
-          "required": [
-
-          ]
+          "required": []
         }
       },
       "required": [
@@ -1213,8 +1205,14 @@
         }
       }
     },
-    "/recipe_steps/{id}": {
+    "/recipes/{recipe_id}/recipe_steps/{id}": {
       "parameters": [
+        {
+          "name": "recipe_id",
+          "in": "path",
+          "type": "integer",
+          "required": true
+        },
         {
           "name": "user_email",
           "in": "query",

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -530,7 +530,7 @@
         },
         "type": {
           "type": "string",
-          "example": "ingredient"
+          "example": "recipe"
         },
         "attributes": {
           "type": "object",

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -6,6 +6,112 @@
   },
   "basePath": "/api/v1",
   "definitions": {
+    "recipe_step_update": {
+      "type": "object",
+      "properties": {
+        "number": {
+          "type": "integer",
+          "example": 2,
+          "x-nullable": false
+        },
+        "description": {
+          "type": "string",
+          "example": "Prender el horno",
+          "x-nullable": true
+        }
+      }
+    },
+    "recipe_step_response": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "example": "1"
+        },
+        "type": {
+          "type": "string",
+          "example": "recipe_step"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "number": {
+              "type": "integer",
+              "example": 1,
+              "x-nullable": true
+            },
+            "description": {
+              "type": "string",
+              "example": "Prender el horno",
+              "x-nullable": true
+            },
+            "media_url": {
+              "type": "string",
+              "example": "https://some-media-url.com",
+              "x-nullable": true
+            },
+            "recipe_id": {
+              "type": "integer",
+              "example": 1,
+              "x-nullable": true
+            },
+            "created_at": {
+              "type": "string",
+              "example": "1984-06-04 09:00",
+              "x-nullable": true
+            },
+            "updated_at": {
+              "type": "string",
+              "example": "1984-06-04 09:00",
+              "x-nullable": true
+            }
+          },
+          "required": [
+
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ]
+    },
+    "recipe_step": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "example": "Prender el horno",
+          "x-nullable": true
+        }
+      }
+    },
+    "recipe_steps_collection": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/recipe_step_response"
+          }
+        }
+      },
+      "required": [
+        "data"
+      ]
+    },
+    "recipe_step_resource": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/recipe_step_response"
+        }
+      },
+      "required": [
+        "data"
+      ]
+    },
     "user": {
       "type": "object",
       "properties": {
@@ -149,7 +255,9 @@
               "x-nullable": true
             }
           },
-          "required": []
+          "required": [
+
+          ]
         }
       },
       "required": [
@@ -248,7 +356,9 @@
               "x-nullable": true
             }
           },
-          "required": []
+          "required": [
+
+          ]
         }
       },
       "required": [
@@ -325,7 +435,9 @@
               "x-nullable": true
             }
           },
-          "required": []
+          "required": [
+
+          ]
         }
       },
       "required": [
@@ -372,11 +484,6 @@
           "example": 4,
           "x-nullable": true
         },
-        "instructions": {
-          "type": "string",
-          "example": "Some instructions",
-          "x-nullable": true
-        },
         "cook_minutes": {
           "type": "integer",
           "example": 25,
@@ -386,7 +493,6 @@
       "required": [
         "name",
         "portions",
-        "instructions",
         "cook_minutes"
       ]
     },
@@ -444,11 +550,6 @@
               "example": 4,
               "x-nullable": true
             },
-            "instructions": {
-              "type": "string",
-              "example": "Some instructions",
-              "x-nullable": true
-            },
             "cook_minutes": {
               "type": "integer",
               "example": 25,
@@ -469,9 +570,17 @@
               "items": {
                 "$ref": "#/definitions/ingredient_response"
               }
+            },
+            "steps": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/recipe_step_response"
+              }
             }
           },
-          "required": []
+          "required": [
+
+          ]
         }
       },
       "required": [
@@ -1042,6 +1151,134 @@
           },
           "404": {
             "description": "provider not found"
+          },
+          "401": {
+            "description": "user unauthorized"
+          }
+        }
+      }
+    },
+    "/recipes/{recipe_id}/recipe_steps": {
+      "parameters": [
+        {
+          "name": "recipe_id",
+          "in": "path",
+          "type": "integer",
+          "required": true
+        },
+        {
+          "name": "user_email",
+          "in": "query",
+          "type": "string"
+        },
+        {
+          "name": "user_token",
+          "in": "query",
+          "type": "string"
+        }
+      ],
+      "post": {
+        "summary": "Creates Recipe Step",
+        "description": "Creates Recipe Step",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "recipe_step",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "recipe_step": {
+                  "$ref": "#/definitions/recipe_step"
+                }
+              },
+              "required": [
+                "recipe_step"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "recipe_step created"
+          },
+          "401": {
+            "description": "user unauthorized"
+          }
+        }
+      }
+    },
+    "/recipe_steps/{id}": {
+      "parameters": [
+        {
+          "name": "user_email",
+          "in": "query",
+          "type": "string"
+        },
+        {
+          "name": "user_token",
+          "in": "query",
+          "type": "string"
+        },
+        {
+          "name": "id",
+          "in": "path",
+          "type": "integer",
+          "required": true
+        }
+      ],
+      "put": {
+        "summary": "Updates Recipe Step",
+        "description": "Updates Recipe Step",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "recipe_step",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "recipe_step": {
+                  "$ref": "#/definitions/recipe_step_update"
+                }
+              },
+              "required": [
+                "recipe_step"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "recipe_step updated"
+          },
+          "401": {
+            "description": "user unauthorized"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Deletes Recipe Step",
+        "produces": [
+          "application/json"
+        ],
+        "description": "Deletes specific recipe_step",
+        "responses": {
+          "204": {
+            "description": "recipe_step deleted"
+          },
+          "404": {
+            "description": "recipe_step not found"
           },
           "401": {
             "description": "user unauthorized"


### PR DESCRIPTION
Base #40

### Contexto
En el PR #39 creé el modelo `RecipeSteps` con toda la lógica de pasos en una receta para reemplazar el atributo `instructions`que eliminé en el PR #40. Ahora toca integrarlo a la API 🙂 

### Qué hice

Agregué el controlador de `RecipeStep` que permite crear, editar y eliminar. No es necesario el index o show porque viene integrado en el serializer de `Recipe`.

Agregué las rutas a swagger

### QA

Probar las tres nuevas rutas:
![image](https://user-images.githubusercontent.com/30879716/117467803-0904f200-af22-11eb-80e3-00d1349e731d.png)

Deberían seguir la lógica mencionada en #39, donde si eliminas un paso o lo cambias de posición entonces se actualiza la posición de los demás

