### PR TITLE
BASE[#38] feat(api/recipes): add ingredients to recipes response

### DIFF
--- a/app/serializers/api/v1/recipe_serializer.rb
+++ b/app/serializers/api/v1/recipe_serializer.rb
@@ -8,6 +8,7 @@ class Api::V1::RecipeSerializer < ActiveModel::Serializer
     :instructions,
     :cook_minutes,
     :created_at,
-    :updated_at
+    :updated_at,
+    :ingredients
   )
 end

--- a/spec/swagger/v1/schemas/recipe_schema.rb
+++ b/spec/swagger/v1/schemas/recipe_schema.rb
@@ -28,7 +28,11 @@ RECIPE_RESPONSE_SCHEMA = {
         instructions: { type: :string, example: 'Some instructions', 'x-nullable': true },
         cook_minutes: { type: :integer, example: 25, 'x-nullable': true },
         created_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
-        updated_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true }
+        updated_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
+        ingredients: {
+          type: "array",
+          items: { "$ref" => "#/definitions/ingredient_response" }
+        }
       },
       required: []
     }

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -463,6 +463,12 @@
               "type": "string",
               "example": "1984-06-04 09:00",
               "x-nullable": true
+            },
+            "ingredients": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ingredient_response"
+              }
             }
           },
           "required": []


### PR DESCRIPTION
### Contexto

Estabamos retornando las recetas peladas, había que agregarle los ingredientes que tiene.

### QA

Entrar a `/api-docs` y que esté actualizada la response ideal del GET de `recipe` tanto para el index como una específica. Probar también que efectivamente retorne eso