### PR TITLE
feat(api@recipe-ingredients): add endpoints for recipe ingredients

### DIFF
--- a/app/controllers/api/v1/recipe_ingredients_controller.rb
+++ b/app/controllers/api/v1/recipe_ingredients_controller.rb
@@ -1,0 +1,37 @@
+class Api::V1::RecipeIngredientsController < Api::V1::BaseController
+  acts_as_token_authentication_handler_for User, fallback: :exception
+
+  def create
+    respond_with recipe_ingredients.create!(recipe_ingredient_params)
+  end
+
+  def update
+    respond_with recipe_ingredient.update!(recipe_ingredient_params)
+  end
+
+  def destroy
+    respond_with recipe_ingredient.destroy!
+  end
+
+  private
+
+  def recipe_ingredient
+    @recipe_ingredient ||= recipe_ingredients.find_by!(id: params[:id])
+  end
+
+  def recipe_ingredients
+    @recipe_ingredients ||= recipe.recipe_ingredients
+  end
+
+  def recipe
+    @recipe ||= current_user.recipes.find_by!(id: params[:recipe_id])
+  end
+
+  def recipe_ingredient_params
+    params.require(:recipe_ingredient).permit(
+      :recipe_id,
+      :ingredient_id,
+      :ingredient_quantity
+    )
+  end
+end

--- a/app/serializers/api/v1/recipe_ingredient_serializer.rb
+++ b/app/serializers/api/v1/recipe_ingredient_serializer.rb
@@ -1,0 +1,10 @@
+class Api::V1::RecipeIngredientSerializer < ActiveModel::Serializer
+  type :recipe_ingredient
+
+  attributes(
+    :ingredient,
+    :ingredient_quantity,
+    :created_at,
+    :updated_at
+  )
+end

--- a/app/serializers/api/v1/recipe_serializer.rb
+++ b/app/serializers/api/v1/recipe_serializer.rb
@@ -8,12 +8,18 @@ class Api::V1::RecipeSerializer < ActiveModel::Serializer
     :cook_minutes,
     :created_at,
     :updated_at,
-    :ingredients,
+    :recipe_ingredients,
     :steps
   )
 
   def steps
     ActiveModelSerializers::SerializableResource.new(object.steps.rank(:step_order),
                                                      each_serializer: Api::V1::RecipeStepSerializer)
+  end
+
+  def recipe_ingredients
+    ActiveModelSerializers::SerializableResource.new(
+      object.recipe_ingredients, each_serializer: Api::V1::RecipeIngredientSerializer
+    )
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       resources :providers
       resources :menus
       resources :recipes do
+        resources :recipe_ingredients, only: [:create, :update, :destroy]
         resources :recipe_steps, only: [:create, :update, :destroy]
       end
 

--- a/spec/integration/api/v1/recipe_ingredients_spec.rb
+++ b/spec/integration/api/v1/recipe_ingredients_spec.rb
@@ -1,0 +1,127 @@
+require 'swagger_helper'
+
+# rubocop:disable RSpec/EmptyExampleGroup, RSpec/MultipleMemoizedHelpers
+describe 'API::V1::RecipeIngredients', swagger_doc: 'v1/swagger.json' do
+  let(:user) { create(:user) }
+  let(:user_email) { user.email }
+  let(:user_token) { user.authentication_token }
+
+  let(:recipe) { create(:recipe, user: user) }
+  let(:ingredient) { create(:ingredient, user: user) }
+  let(:recipe_id) { recipe.id }
+
+  path '/recipes/{recipe_id}/recipe_ingredients' do
+    parameter name: :recipe_id, in: :path, type: :integer
+    parameter name: :user_email, in: :query, type: :string
+    parameter name: :user_token, in: :query, type: :string
+
+    post 'Creates Recipe Ingredient' do
+      description 'Creates Recipe Ingredient'
+      consumes 'application/json'
+      produces 'application/json'
+      parameter(
+        name: :recipe_ingredient,
+        in: :body,
+        schema: {
+          type: "object",
+          properties: {
+            recipe_ingredient: { "$ref" => "#/definitions/recipe_ingredient" }
+          },
+          required: [
+            :recipe_ingredient
+          ]
+        }
+      )
+
+      response '201', 'recipe_ingredient created' do
+        let(:recipe_ingredient) do
+          {
+            ingredient_id: ingredient.id,
+            ingredient_quantity: 3
+          }
+        end
+
+        run_test!
+      end
+
+      response '401', 'user unauthorized' do
+        let(:recipe_ingredient) { {} }
+        let(:user_token) { 'invalid' }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/recipes/{recipe_id}/recipe_ingredients/{id}' do
+    parameter name: :recipe_id, in: :path, type: :integer
+    parameter name: :user_email, in: :query, type: :string
+    parameter name: :user_token, in: :query, type: :string
+
+    parameter name: :id, in: :path, type: :integer
+
+    let(:existent_recipe_ingredient) do
+      create(:recipe_ingredient, recipe: recipe, ingredient: ingredient)
+    end
+    let(:id) { existent_recipe_ingredient.id }
+
+    put 'Updates Recipe Ingredient' do
+      description 'Updates Recipe Ingredient'
+      consumes 'application/json'
+      produces 'application/json'
+      parameter(
+        name: :recipe_ingredient,
+        in: :body,
+        schema: {
+          type: "object",
+          properties: {
+            recipe_ingredient: { "$ref" => "#/definitions/recipe_ingredient" }
+          },
+          required: [
+            :recipe_ingredient
+          ]
+        }
+      )
+
+      response '200', 'recipe_ingredient updated' do
+        let(:recipe_ingredient) do
+          {
+            ingredient_id: ingredient.id,
+            ingredient_quantity: 4
+          }
+        end
+
+        run_test!
+      end
+
+      response '401', 'user unauthorized' do
+        let(:recipe_ingredient) { {} }
+        let(:user_token) { 'invalid' }
+
+        run_test!
+      end
+    end
+
+    delete 'Deletes Recipe Ingredient' do
+      produces 'application/json'
+      description 'Deletes specific recipe_ingredient'
+
+      response '204', 'recipe_ingredient deleted' do
+        run_test!
+      end
+
+      response '404', 'recipe_ingredient not found' do
+        let(:id) { 'invalid' }
+
+        run_test!
+      end
+
+      response '401', 'user unauthorized' do
+        let(:user_token) { 'invalid' }
+
+        run_test!
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/EmptyExampleGroup, RSpec/MultipleMemoizedHelpers

--- a/spec/swagger/v1/definition.rb
+++ b/spec/swagger/v1/definition.rb
@@ -6,6 +6,10 @@ API_V1 = {
   },
   basePath: '/api/v1',
   definitions: {
+    recipe_ingredient_response: RECIPE_INGREDIENT_RESPONSE,
+    recipe_ingredient: RECIPE_INGREDIENT_SCHEMA,
+    recipe_ingredients_collection: RECIPE_INGREDIENTS_COLLECTION_SCHEMA,
+    recipe_ingredient_resource: RECIPE_INGREDIENT_RESOURCE_SCHEMA,
     recipe_step_update: RECIPE_STEP_UPDATE_SCHEMA,
     recipe_step_response: RECIPE_STEP_RESPONSE_SCHEMA,
     recipe_step: RECIPE_STEP_SCHEMA,

--- a/spec/swagger/v1/schemas/recipe_ingredient_schema.rb
+++ b/spec/swagger/v1/schemas/recipe_ingredient_schema.rb
@@ -1,0 +1,54 @@
+RECIPE_INGREDIENT_SCHEMA = {
+  type: :object,
+  properties: {
+    ingredient_id: { type: :integer, example: 1, 'x-nullable': false },
+    ingredient_quantity: { type: :integer, example: 3, 'x-nullable': true }
+  }
+}
+
+RECIPE_INGREDIENT_RESPONSE = {
+  type: :object,
+  properties: {
+    id: { type: :string, example: '1' },
+    type: { type: :string, example: 'recipe_ingredient' },
+    attributes: {
+      type: :object,
+      properties: {
+        recipe_id: { type: :integer, example: 1, 'x-nullable': false },
+        ingredient_id: { type: :integer, example: 1, 'x-nullable': false },
+        ingredient_quantity: { type: :integer, example: 3, 'x-nullable': true },
+        created_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
+        updated_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true }
+      },
+      required: []
+    }
+  },
+  required: [
+    :id,
+    :type,
+    :attributes
+  ]
+}
+
+RECIPE_INGREDIENTS_COLLECTION_SCHEMA = {
+  type: "object",
+  properties: {
+    data: {
+      type: "array",
+      items: { "$ref" => "#/definitions/recipe_ingredient" }
+    }
+  },
+  required: [
+    :data
+  ]
+}
+
+RECIPE_INGREDIENT_RESOURCE_SCHEMA = {
+  type: "object",
+  properties: {
+    data: { "$ref" => "#/definitions/recipe_ingredient" }
+  },
+  required: [
+    :data
+  ]
+}

--- a/spec/swagger/v1/schemas/recipe_ingredient_schema.rb
+++ b/spec/swagger/v1/schemas/recipe_ingredient_schema.rb
@@ -15,7 +15,7 @@ RECIPE_INGREDIENT_RESPONSE = {
       type: :object,
       properties: {
         recipe_id: { type: :integer, example: 1, 'x-nullable': false },
-        ingredient_id: { type: :integer, example: 1, 'x-nullable': false },
+        ingredient: { "$ref" => "#/definitions/ingredient_response" },
         ingredient_quantity: { type: :integer, example: 3, 'x-nullable': true },
         created_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
         updated_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true }

--- a/spec/swagger/v1/schemas/recipe_schema.rb
+++ b/spec/swagger/v1/schemas/recipe_schema.rb
@@ -26,9 +26,14 @@ RECIPE_RESPONSE_SCHEMA = {
         cook_minutes: { type: :integer, example: 25, 'x-nullable': true },
         created_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
         updated_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
-        ingredients: {
-          type: "array",
-          items: { "$ref" => "#/definitions/ingredient_response" }
+        recipe_ingredients: {
+          type: "object",
+          properties: {
+            data: {
+              type: "array",
+              items: { "$ref" => "#/definitions/recipe_ingredient_response" }
+            }
+          }
         },
         steps: {
           type: "object",

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -25,10 +25,8 @@
               "example": 1,
               "x-nullable": false
             },
-            "ingredient_id": {
-              "type": "integer",
-              "example": 1,
-              "x-nullable": false
+            "ingredient": {
+              "$ref": "#/definitions/ingredient_response"
             },
             "ingredient_quantity": {
               "type": "integer",
@@ -646,10 +644,15 @@
               "example": "1984-06-04 09:00",
               "x-nullable": true
             },
-            "ingredients": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ingredient_response"
+            "recipe_ingredients": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/recipe_ingredient_response"
+                  }
+                }
               }
             },
             "steps": {

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -6,6 +6,95 @@
   },
   "basePath": "/api/v1",
   "definitions": {
+    "recipe_ingredient_response": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "example": "1"
+        },
+        "type": {
+          "type": "string",
+          "example": "recipe_ingredient"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "recipe_id": {
+              "type": "integer",
+              "example": 1,
+              "x-nullable": false
+            },
+            "ingredient_id": {
+              "type": "integer",
+              "example": 1,
+              "x-nullable": false
+            },
+            "ingredient_quantity": {
+              "type": "integer",
+              "example": 3,
+              "x-nullable": true
+            },
+            "created_at": {
+              "type": "string",
+              "example": "1984-06-04 09:00",
+              "x-nullable": true
+            },
+            "updated_at": {
+              "type": "string",
+              "example": "1984-06-04 09:00",
+              "x-nullable": true
+            }
+          },
+          "required": []
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ]
+    },
+    "recipe_ingredient": {
+      "type": "object",
+      "properties": {
+        "ingredient_id": {
+          "type": "integer",
+          "example": 1,
+          "x-nullable": false
+        },
+        "ingredient_quantity": {
+          "type": "integer",
+          "example": 3,
+          "x-nullable": true
+        }
+      }
+    },
+    "recipe_ingredients_collection": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/recipe_ingredient"
+          }
+        }
+      },
+      "required": [
+        "data"
+      ]
+    },
+    "recipe_ingredient_resource": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/recipe_ingredient"
+        }
+      },
+      "required": [
+        "data"
+      ]
+    },
     "recipe_step_update": {
       "type": "object",
       "properties": {
@@ -429,9 +518,7 @@
               "x-nullable": true
             }
           },
-          "required": [
-
-          ]
+          "required": []
         }
       },
       "required": [
@@ -1148,6 +1235,140 @@
           },
           "404": {
             "description": "provider not found"
+          },
+          "401": {
+            "description": "user unauthorized"
+          }
+        }
+      }
+    },
+    "/recipes/{recipe_id}/recipe_ingredients": {
+      "parameters": [
+        {
+          "name": "recipe_id",
+          "in": "path",
+          "type": "integer",
+          "required": true
+        },
+        {
+          "name": "user_email",
+          "in": "query",
+          "type": "string"
+        },
+        {
+          "name": "user_token",
+          "in": "query",
+          "type": "string"
+        }
+      ],
+      "post": {
+        "summary": "Creates Recipe Ingredient",
+        "description": "Creates Recipe Ingredient",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "recipe_ingredient",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "recipe_ingredient": {
+                  "$ref": "#/definitions/recipe_ingredient"
+                }
+              },
+              "required": [
+                "recipe_ingredient"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "recipe_ingredient created"
+          },
+          "401": {
+            "description": "user unauthorized"
+          }
+        }
+      }
+    },
+    "/recipes/{recipe_id}/recipe_ingredients/{id}": {
+      "parameters": [
+        {
+          "name": "recipe_id",
+          "in": "path",
+          "type": "integer",
+          "required": true
+        },
+        {
+          "name": "user_email",
+          "in": "query",
+          "type": "string"
+        },
+        {
+          "name": "user_token",
+          "in": "query",
+          "type": "string"
+        },
+        {
+          "name": "id",
+          "in": "path",
+          "type": "integer",
+          "required": true
+        }
+      ],
+      "put": {
+        "summary": "Updates Recipe Ingredient",
+        "description": "Updates Recipe Ingredient",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "recipe_ingredient",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "recipe_ingredient": {
+                  "$ref": "#/definitions/recipe_ingredient"
+                }
+              },
+              "required": [
+                "recipe_ingredient"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "recipe_ingredient updated"
+          },
+          "401": {
+            "description": "user unauthorized"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Deletes Recipe Ingredient",
+        "produces": [
+          "application/json"
+        ],
+        "description": "Deletes specific recipe_ingredient",
+        "responses": {
+          "204": {
+            "description": "recipe_ingredient deleted"
+          },
+          "404": {
+            "description": "recipe_ingredient not found"
           },
           "401": {
             "description": "user unauthorized"


### PR DESCRIPTION
Agrego las CRUD operations para agregar ingredientes a una receta.

![image](https://user-images.githubusercontent.com/30879716/118057537-2c80d000-b35a-11eb-973c-a9f7b2a69dfe.png)

No hay `show` ni `index` porque están implícitas en la response de `Recipe`, es decir, cuando se hace un `get` de alguna receta o de todas, aparecen con sus ingredientes.

Al final este modelo sirve para relacionar ingredientes ya existentes del usuario con recetas ya existentes del usuario.

### QA

- Intentar agregar un ingrediente existente y no existente a una receta
- Hacer GET de esa receta y ver que esté en sus ingredientes
- Hacer update de la relación, aumentando la cantidad
- Eliminando la relación