### PR TITLE
fix(recipes/show): add show route in recipes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,6 @@ Rails.application.routes.draw do
   mount Sidekiq::Web => '/queue'
 
   resources :ingredients, only: [:index]
-  resources :recipes, only: [:index]
+  resources :recipes, only: [:index, :show]
   resources :menus, only: [:index, :new]
 end


### PR DESCRIPTION
# Qué hice
- Al hacer el _merge_ de una PR se perdió la ruta show de recipes, por lo que en esta PR se vuelve a agregar, agregando nuevamente :show a recipes en routes.rb

#QA
- Correr la app
- Ir a /recipes
- Apretar el botón para ver una receta en específico
- Debe llevar a una vista propia de la receta en la ruta recipes/{id} (con id correspondiente al id de esa receta)