### PR TITLE
feat(api@recipes): accept nested attributes from recipe steps

### DIFF
--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -35,7 +35,8 @@ class Api::V1::RecipesController < Api::V1::BaseController
     params.require(:recipe).permit(
       :name,
       :portions,
-      :cook_minutes
+      :cook_minutes,
+      steps_attributes: [:description, :media_url]
     )
   end
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -5,6 +5,7 @@ class Recipe < ApplicationRecord
   has_many :recipe_ingredients, dependent: :destroy
   has_many :ingredients, through: :recipe_ingredients, dependent: nil
   has_many :steps, dependent: :destroy, class_name: "RecipeStep"
+  accepts_nested_attributes_for :steps
 end
 
 # == Schema Information

--- a/app/models/recipe_step.rb
+++ b/app/models/recipe_step.rb
@@ -6,7 +6,7 @@ class RecipeStep < ApplicationRecord
   before_validation :set_initial_step_order, on: :create
 
   validates :description, presence: true
-  ranks :step_order
+  ranks :step_order, with_same: :recipe_id
 end
 
 def set_initial_step_order

--- a/spec/swagger/v1/schemas/recipe_schema.rb
+++ b/spec/swagger/v1/schemas/recipe_schema.rb
@@ -3,7 +3,17 @@ RECIPE_SCHEMA = {
   properties: {
     name: { type: :string, example: 'Pastel de choclo', 'x-nullable': true },
     portions: { type: :integer, example: 4, 'x-nullable': true },
-    cook_minutes: { type: :integer, example: 25, 'x-nullable': true }
+    cook_minutes: { type: :integer, example: 25, 'x-nullable': true },
+    steps_attributes: {
+      type: "array",
+      items: {
+        type: :object,
+        properties: {
+          description: { type: :string, example: 'Horneamos la masa', 'x-nullable': false },
+          media_url: { type: :string, example: 'https://media-url', 'x-nullable': true }
+        }
+      }
+    }
   },
   required: [
     :name,

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -248,7 +248,7 @@
             },
             "country": {
               "type": "string",
-              "exampel": "CL"
+              "example": "CL"
             }
           }
         },
@@ -621,6 +621,24 @@
           "type": "integer",
           "example": 25,
           "x-nullable": true
+        },
+        "steps_attributes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string",
+                "example": "Horneamos la masa",
+                "x-nullable": false
+              },
+              "media_url": {
+                "type": "string",
+                "example": "https://media-url",
+                "x-nullable": true
+              }
+            }
+          }
         }
       },
       "required": [


### PR DESCRIPTION
Ahora se pueden pasar los pasos (en orden) al crear una receta para no tener que hacer llamados al endpoint de crear paso todo el rato

![image](https://user-images.githubusercontent.com/30879716/118746920-10cc6c80-b827-11eb-9ba5-46b979324d90.png)


### QA

Hacer llamado POST a `http://localhost:3000/api/v1/recipes?user_email=test%2Buser1%40platan.us&user_token={token_primer_usuario}` con
```
  {
    "recipe": {
      "name": "Pastel de choclo",
      "portions": 4,
      "cook_minutes": 25,
      "steps_attributes": [
        {
          "description": "Horneamos la masa"      
        },
        {
          "description": "Hacemos la crema"        
        }
      ]
    }
  }
```
y debería crear la receta junto con dos pasos rankeados (como se ve en la foto)