### PR TITLE
feat(api): add menu recipes endpoints

### DIFF
--- a/app/controllers/api/v1/menu_recipes_controller.rb
+++ b/app/controllers/api/v1/menu_recipes_controller.rb
@@ -1,0 +1,42 @@
+class Api::V1::MenuRecipesController < Api::V1::BaseController
+  acts_as_token_authentication_handler_for User, fallback: :exception
+  before_action :verify_owned_recipe, only: [:create, :update]
+
+  def create
+    respond_with menu_recipes.create!(menu_recipe_params)
+  end
+
+  def update
+    respond_with menu_recipe.update!(menu_recipe_params)
+  end
+
+  def destroy
+    respond_with menu_recipe.destroy!
+  end
+
+  private
+
+  def menu_recipe
+    @menu_recipe ||= menu_recipes.find_by!(id: params[:id])
+  end
+
+  def menu_recipes
+    @menu_recipes ||= menu.menu_recipes
+  end
+
+  def menu
+    @menu ||= current_user.menus.find_by!(id: params[:menu_id])
+  end
+
+  def verify_owned_recipe
+    current_user.recipes.find_by!(id: menu_recipe_params[:recipe_id])
+  end
+
+  def menu_recipe_params
+    params.require(:menu_recipe).permit(
+      :menu_id,
+      :recipe_id,
+      :recipe_quantity
+    )
+  end
+end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -2,10 +2,6 @@ class Menu < ApplicationRecord
   belongs_to :user
   has_many :menu_recipes, dependent: :destroy
   has_many :recipes, through: :menu_recipes, dependent: nil
-
-  def recipes_menu
-    menu_recipes.map { |r| [r.recipe, r.recipe_quantity] }
-  end
 end
 
 # == Schema Information

--- a/app/serializers/api/v1/menu_recipe_serializer.rb
+++ b/app/serializers/api/v1/menu_recipe_serializer.rb
@@ -1,0 +1,10 @@
+class Api::V1::MenuRecipeSerializer < ActiveModel::Serializer
+  type :menu_recipe
+
+  attributes(
+    :recipe,
+    :recipe_quantity,
+    :created_at,
+    :updated_at
+  )
+end

--- a/app/serializers/api/v1/menu_serializer.rb
+++ b/app/serializers/api/v1/menu_serializer.rb
@@ -3,8 +3,14 @@ class Api::V1::MenuSerializer < ActiveModel::Serializer
 
   attributes(
     :name,
-    :recipes_menu,
+    :menu_recipes,
     :created_at,
     :updated_at
   )
+
+  def menu_recipes
+    ActiveModelSerializers::SerializableResource.new(
+      object.menu_recipes, each_serializer: Api::V1::MenuRecipeSerializer
+    )
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
     api_version(module: 'Api::V1', path: { value: 'v1' }, defaults: { format: 'json' }) do
       resources :ingredients
       resources :providers
-      resources :menus
+      resources :menus do
+        resources :menu_recipes, only: [:create, :update, :destroy]
+      end
       resources :recipes do
         resources :recipe_ingredients, only: [:create, :update, :destroy]
         resources :recipe_steps, only: [:create, :update, :destroy]

--- a/spec/integration/api/v1/menu_recipes_spec.rb
+++ b/spec/integration/api/v1/menu_recipes_spec.rb
@@ -1,0 +1,140 @@
+require 'swagger_helper'
+
+# rubocop:disable RSpec/EmptyExampleGroup, RSpec/MultipleMemoizedHelpers
+describe 'API::V1::MenuRecipes', swagger_doc: 'v1/swagger.json' do
+  let(:user) { create(:user) }
+  let(:user_email) { user.email }
+  let(:user_token) { user.authentication_token }
+
+  let(:menu) { create(:menu, user: user) }
+  let(:recipe) { create(:recipe, user: user) }
+  let(:menu_id) { menu.id }
+
+  path '/menus/{menu_id}/menu_recipes' do
+    parameter name: :menu_id, in: :path, type: :integer
+    parameter name: :user_email, in: :query, type: :string
+    parameter name: :user_token, in: :query, type: :string
+
+    post 'Creates Menu Recipe' do
+      description 'Creates Menu Recipe'
+      consumes 'application/json'
+      produces 'application/json'
+      parameter(
+        name: :menu_recipe,
+        in: :body,
+        schema: {
+          type: "object",
+          properties: {
+            menu_recipe: { "$ref" => "#/definitions/menu_recipe" }
+          },
+          required: [
+            :menu_recipe
+          ]
+        }
+      )
+
+      response '201', 'menu_recipe created' do
+        let(:menu_recipe) do
+          {
+            recipe_id: recipe.id,
+            recipe_quantity: 3
+          }
+        end
+
+        run_test!
+      end
+
+      response '401', 'user unauthorized' do
+        let(:menu_recipe) { {} }
+        let(:user_token) { 'invalid' }
+
+        run_test!
+      end
+
+      response '404', 'recipe not found' do
+        let!(:other_user_recipe) { create(:recipe) }
+        let(:menu_recipe) do
+          {
+            recipe_id: other_user_recipe.id,
+            recipe_quantity: 3
+          }
+        end
+        let(:recipe_id) { 'invalid' }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/menus/{menu_id}/menu_recipes/{id}' do
+    parameter name: :menu_id, in: :path, type: :integer
+    parameter name: :user_email, in: :query, type: :string
+    parameter name: :user_token, in: :query, type: :string
+
+    parameter name: :id, in: :path, type: :integer
+
+    let(:existent_menu_recipe) do
+      create(:menu_recipe, menu: menu, recipe: recipe)
+    end
+    let(:id) { existent_menu_recipe.id }
+
+    put 'Updates Menu Recipe' do
+      description 'Updates Menu Recipe'
+      consumes 'application/json'
+      produces 'application/json'
+      parameter(
+        name: :menu_recipe,
+        in: :body,
+        schema: {
+          type: "object",
+          properties: {
+            menu_recipe: { "$ref" => "#/definitions/menu_recipe" }
+          },
+          required: [
+            :menu_recipe
+          ]
+        }
+      )
+
+      response '200', 'menu_recipe updated' do
+        let(:menu_recipe) do
+          {
+            recipe_id: recipe.id,
+            recipe_quantity: 4
+          }
+        end
+
+        run_test!
+      end
+
+      response '401', 'user unauthorized' do
+        let(:menu_recipe) { {} }
+        let(:user_token) { 'invalid' }
+
+        run_test!
+      end
+    end
+
+    delete 'Deletes Menu Recipe' do
+      produces 'application/json'
+      description 'Deletes specific menu_recipe'
+
+      response '204', 'menu_recipe deleted' do
+        run_test!
+      end
+
+      response '404', 'menu_recipe not found' do
+        let(:id) { 'invalid' }
+
+        run_test!
+      end
+
+      response '401', 'user unauthorized' do
+        let(:user_token) { 'invalid' }
+
+        run_test!
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/EmptyExampleGroup, RSpec/MultipleMemoizedHelpers

--- a/spec/swagger/v1/definition.rb
+++ b/spec/swagger/v1/definition.rb
@@ -6,6 +6,10 @@ API_V1 = {
   },
   basePath: '/api/v1',
   definitions: {
+    menu_recipe_response: MENU_RECIPE_RESPONSE,
+    menu_recipe: MENU_RECIPE_SCHEMA,
+    menu_recipes_collection: MENU_RECIPES_COLLECTION_SCHEMA,
+    menu_recipe_resource: MENU_RECIPE_RESOURCE_SCHEMA,
     recipe_ingredient_response: RECIPE_INGREDIENT_RESPONSE,
     recipe_ingredient: RECIPE_INGREDIENT_SCHEMA,
     recipe_ingredients_collection: RECIPE_INGREDIENTS_COLLECTION_SCHEMA,

--- a/spec/swagger/v1/schemas/menu_recipe_schema.rb
+++ b/spec/swagger/v1/schemas/menu_recipe_schema.rb
@@ -1,0 +1,54 @@
+MENU_RECIPE_SCHEMA = {
+  type: :object,
+  properties: {
+    recipe_id: { type: :integer, example: 1, 'x-nullable': false },
+    recipe_quantity: { type: :integer, example: 3, 'x-nullable': true }
+  }
+}
+
+MENU_RECIPE_RESPONSE = {
+  type: :object,
+  properties: {
+    id: { type: :string, example: '1' },
+    type: { type: :string, example: 'menu_recipe' },
+    attributes: {
+      type: :object,
+      properties: {
+        menu_id: { type: :integer, example: 1, 'x-nullable': false },
+        recipe: { "$ref" => "#/definitions/recipe_response" },
+        recipe_quantity: { type: :integer, example: 3, 'x-nullable': true },
+        created_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
+        updated_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true }
+      },
+      required: []
+    }
+  },
+  required: [
+    :id,
+    :type,
+    :attributes
+  ]
+}
+
+MENU_RECIPES_COLLECTION_SCHEMA = {
+  type: "object",
+  properties: {
+    data: {
+      type: "array",
+      items: { "$ref" => "#/definitions/menu_recipe" }
+    }
+  },
+  required: [
+    :data
+  ]
+}
+
+MENU_RECIPE_RESOURCE_SCHEMA = {
+  type: "object",
+  properties: {
+    data: { "$ref" => "#/definitions/menu_recipe" }
+  },
+  required: [
+    :data
+  ]
+}

--- a/spec/swagger/v1/schemas/menu_schema.rb
+++ b/spec/swagger/v1/schemas/menu_schema.rb
@@ -18,7 +18,16 @@ MENU_RESPONSE_SCHEMA = {
       properties: {
         name: { type: :string, example: 'Menú de almuerzo', 'x-nullable': true },
         created_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
-        updated_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true }
+        updated_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
+        menu_recipes: {
+          type: "object",
+          properties: {
+            data: {
+              type: "array",
+              items: { "$ref" => "#/definitions/menu_recipe_response" }
+            }
+          }
+        }
       },
       required: []
     }

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -6,6 +6,93 @@
   },
   "basePath": "/api/v1",
   "definitions": {
+    "menu_recipe_response": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "example": "1"
+        },
+        "type": {
+          "type": "string",
+          "example": "menu_recipe"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "menu_id": {
+              "type": "integer",
+              "example": 1,
+              "x-nullable": false
+            },
+            "recipe": {
+              "$ref": "#/definitions/recipe_response"
+            },
+            "recipe_quantity": {
+              "type": "integer",
+              "example": 3,
+              "x-nullable": true
+            },
+            "created_at": {
+              "type": "string",
+              "example": "1984-06-04 09:00",
+              "x-nullable": true
+            },
+            "updated_at": {
+              "type": "string",
+              "example": "1984-06-04 09:00",
+              "x-nullable": true
+            }
+          },
+          "required": []
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ]
+    },
+    "menu_recipe": {
+      "type": "object",
+      "properties": {
+        "recipe_id": {
+          "type": "integer",
+          "example": 1,
+          "x-nullable": false
+        },
+        "recipe_quantity": {
+          "type": "integer",
+          "example": 3,
+          "x-nullable": true
+        }
+      }
+    },
+    "menu_recipes_collection": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/menu_recipe"
+          }
+        }
+      },
+      "required": [
+        "data"
+      ]
+    },
+    "menu_recipe_resource": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/menu_recipe"
+        }
+      },
+      "required": [
+        "data"
+      ]
+    },
     "recipe_ingredient_response": {
       "type": "object",
       "properties": {
@@ -568,6 +655,17 @@
               "type": "string",
               "example": "1984-06-04 09:00",
               "x-nullable": true
+            },
+            "menu_recipes": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/menu_recipe_response"
+                  }
+                }
+              }
             }
           },
           "required": []
@@ -1053,6 +1151,143 @@
           },
           "404": {
             "description": "ingredient not found"
+          },
+          "401": {
+            "description": "user unauthorized"
+          }
+        }
+      }
+    },
+    "/menus/{menu_id}/menu_recipes": {
+      "parameters": [
+        {
+          "name": "menu_id",
+          "in": "path",
+          "type": "integer",
+          "required": true
+        },
+        {
+          "name": "user_email",
+          "in": "query",
+          "type": "string"
+        },
+        {
+          "name": "user_token",
+          "in": "query",
+          "type": "string"
+        }
+      ],
+      "post": {
+        "summary": "Creates Menu Recipe",
+        "description": "Creates Menu Recipe",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "menu_recipe",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "menu_recipe": {
+                  "$ref": "#/definitions/menu_recipe"
+                }
+              },
+              "required": [
+                "menu_recipe"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "menu_recipe created"
+          },
+          "401": {
+            "description": "user unauthorized"
+          },
+          "404": {
+            "description": "recipe not found"
+          }
+        }
+      }
+    },
+    "/menus/{menu_id}/menu_recipes/{id}": {
+      "parameters": [
+        {
+          "name": "menu_id",
+          "in": "path",
+          "type": "integer",
+          "required": true
+        },
+        {
+          "name": "user_email",
+          "in": "query",
+          "type": "string"
+        },
+        {
+          "name": "user_token",
+          "in": "query",
+          "type": "string"
+        },
+        {
+          "name": "id",
+          "in": "path",
+          "type": "integer",
+          "required": true
+        }
+      ],
+      "put": {
+        "summary": "Updates Menu Recipe",
+        "description": "Updates Menu Recipe",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "menu_recipe",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "menu_recipe": {
+                  "$ref": "#/definitions/menu_recipe"
+                }
+              },
+              "required": [
+                "menu_recipe"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "menu_recipe updated"
+          },
+          "401": {
+            "description": "user unauthorized"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Deletes Menu Recipe",
+        "produces": [
+          "application/json"
+        ],
+        "description": "Deletes specific menu_recipe",
+        "responses": {
+          "204": {
+            "description": "menu_recipe deleted"
+          },
+          "404": {
+            "description": "menu_recipe not found"
           },
           "401": {
             "description": "user unauthorized"


### PR DESCRIPTION
Agrego los endpoints para agregar recetas a un menú, además de poder verlas al hacer GET de un menú.

![image](https://user-images.githubusercontent.com/30879716/119243008-fc42e980-bb30-11eb-9f90-cd3a01152207.png)

### QA

Probar los endpoints anteriores con los distintos casos:
- Agregar receta que no es tuya a un menú
- Agregar receta que si es tuya
- Editar la cantidad de esa receta en el menú
- Ver en el GET de un menú específico (o de todos /menus) que aparezcan las recetas asociadas con sus cantidades
- Eliminar una receta de un menú