### PR TITLE
fix(recipe-ingredients): add user ingredients only constraint

### DIFF
--- a/app/controllers/api/v1/recipe_ingredients_controller.rb
+++ b/app/controllers/api/v1/recipe_ingredients_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::RecipeIngredientsController < Api::V1::BaseController
   acts_as_token_authentication_handler_for User, fallback: :exception
+  before_action :verify_owned_ingredient, only: [:create, :update]
 
   def create
     respond_with recipe_ingredients.create!(recipe_ingredient_params)
@@ -25,6 +26,10 @@ class Api::V1::RecipeIngredientsController < Api::V1::BaseController
 
   def recipe
     @recipe ||= current_user.recipes.find_by!(id: params[:recipe_id])
+  end
+
+  def verify_owned_ingredient
+    current_user.ingredients.find_by!(id: recipe_ingredient_params[:ingredient_id])
   end
 
   def recipe_ingredient_params

--- a/spec/integration/api/v1/recipe_ingredients_spec.rb
+++ b/spec/integration/api/v1/recipe_ingredients_spec.rb
@@ -50,6 +50,18 @@ describe 'API::V1::RecipeIngredients', swagger_doc: 'v1/swagger.json' do
 
         run_test!
       end
+
+      response '404', 'ingredient is not of user' do
+        let(:other_user_ingredient) { create(:ingredient) }
+        let(:recipe_ingredient) do
+          {
+            ingredient_id: other_user_ingredient.id,
+            ingredient_quantity: 3
+          }
+        end
+
+        run_test!
+      end
     end
   end
 
@@ -97,6 +109,18 @@ describe 'API::V1::RecipeIngredients', swagger_doc: 'v1/swagger.json' do
       response '401', 'user unauthorized' do
         let(:recipe_ingredient) { {} }
         let(:user_token) { 'invalid' }
+
+        run_test!
+      end
+
+      response '404', 'ingredient is not of user' do
+        let(:other_user_ingredient) { create(:ingredient) }
+        let(:recipe_ingredient) do
+          {
+            ingredient_id: other_user_ingredient.id,
+            ingredient_quantity: 3
+          }
+        end
 
         run_test!
       end

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -1416,6 +1416,9 @@
           },
           "401": {
             "description": "user unauthorized"
+          },
+          "404": {
+            "description": "ingredient is not of user"
           }
         }
       }
@@ -1477,6 +1480,9 @@
           },
           "401": {
             "description": "user unauthorized"
+          },
+          "404": {
+            "description": "ingredient is not of user"
           }
         }
       },


### PR DESCRIPTION
Cuando creamos los endpoints para agregar ingredientes a una receta, verificamos que esté loggeado y que la receta sea de ese usuario.

Ahora sumo que el ingrediente también tiene que ser del usuario, que antes no estaba 😢 

### QA

- Intentar hacer POST a `api/v1/recipes/{recipe_id}/recipe_ingredients` con una receta que no es tuya
- Intentar hacer POST a `api/v1/recipes/{recipe_id}/recipe_ingredients` con un ingrediente que no es tuyo