### PR TITLE
[BASE #58] feat(api@menus): add nested recipes relation

### DIFF
--- a/app/controllers/api/v1/menus_controller.rb
+++ b/app/controllers/api/v1/menus_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::MenusController < Api::V1::BaseController
   acts_as_token_authentication_handler_for User
+  before_action :verify_owned_recipes, only: [:create, :update]
 
   def index
     respond_with menus
@@ -31,9 +32,18 @@ class Api::V1::MenusController < Api::V1::BaseController
     @menus ||= current_user.menus
   end
 
+  def verify_owned_recipes
+    menu_recipes_attributes = menu_params[:menu_recipes_attributes]
+    return if menu_recipes_attributes.blank?
+
+    recipe_ids = menu_recipes_attributes.map { |menu_recipe| menu_recipe['recipe_id'] }
+    current_user.recipes.find(recipe_ids)
+  end
+
   def menu_params
     params.require(:menu).permit(
-      :name
+      :name,
+      menu_recipes_attributes: [:recipe_id, :recipe_quantity]
     )
   end
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -2,6 +2,7 @@ class Menu < ApplicationRecord
   belongs_to :user
   has_many :menu_recipes, dependent: :destroy
   has_many :recipes, through: :menu_recipes, dependent: nil
+  accepts_nested_attributes_for :menu_recipes
 end
 
 # == Schema Information

--- a/spec/integration/api/v1/menus_spec.rb
+++ b/spec/integration/api/v1/menus_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
-describe 'ApiV1::Menus', swagger_doc: 'v1/swagger.json' do
+# rubocop:disable RSpec/EmptyExampleGroup, RSpec/MultipleMemoizedHelpers
+describe 'Api::V1::Menus', swagger_doc: 'v1/swagger.json' do
   let!(:user) { create(:user) }
   let(:user_email) { user.email }
   let(:user_token) { user.authentication_token }
@@ -50,6 +51,23 @@ describe 'ApiV1::Menus', swagger_doc: 'v1/swagger.json' do
         let(:menu) do
           {
             name: 'Some name'
+          }
+        end
+
+        run_test!
+      end
+
+      response '404', 'recipe not of user' do
+        let!(:other_user_recipe) { create(:recipe) }
+        let(:menu) do
+          {
+            name: 'Some name',
+            menu_recipes_attributes: [
+              {
+                recipe_id: other_user_recipe.id,
+                recipe_quantity: 5
+              }
+            ]
           }
         end
 
@@ -126,3 +144,4 @@ describe 'ApiV1::Menus', swagger_doc: 'v1/swagger.json' do
     end
   end
 end
+# rubocop:enable RSpec/EmptyExampleGroup, RSpec/MultipleMemoizedHelpers

--- a/spec/swagger/v1/schemas/menu_schema.rb
+++ b/spec/swagger/v1/schemas/menu_schema.rb
@@ -1,7 +1,17 @@
 MENU_SCHEMA = {
   type: :object,
   properties: {
-    name: { type: :string, example: 'Menú de almuerzo', 'x-nullable': true }
+    name: { type: :string, example: 'Menú de almuerzo', 'x-nullable': true },
+    menu_recipes_attributes: {
+      type: "array",
+      items: {
+        type: :object,
+        properties: {
+          recipe_id: { type: :integer, example: 1, 'x-nullable': false },
+          recipe_quantity: { type: :integer, example: 5, 'x-nullable': true }
+        }
+      }
+    }
   },
   required: [
     :name

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -621,6 +621,24 @@
           "type": "string",
           "example": "Menú de almuerzo",
           "x-nullable": true
+        },
+        "menu_recipes_attributes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "recipe_id": {
+                "type": "integer",
+                "example": 1,
+                "x-nullable": false
+              },
+              "recipe_quantity": {
+                "type": "integer",
+                "example": 5,
+                "x-nullable": true
+              }
+            }
+          }
         }
       },
       "required": [
@@ -1352,6 +1370,9 @@
         "responses": {
           "201": {
             "description": "menu created"
+          },
+          "404": {
+            "description": "recipe not of user"
           }
         }
       }


### PR DESCRIPTION
BASE #58

Se pasa como atributo opcional las recetas que puede tener un menú, junto con sus cantidades. Solo se puede crear con recetas que le pertenecen.

![image](https://user-images.githubusercontent.com/30879716/119274726-54382980-bbdf-11eb-86f0-b77bda130b07.png)


### QA

Crear un menú con distintas recetas, que existan, que no existan, que sean tuyas o no.