### PR TITLE
Frontend/backend create recipes with steps

### DIFF
--- a/app/javascript/api/recipes.js
+++ b/app/javascript/api/recipes.js
@@ -18,4 +18,11 @@ function deleteRecipe(recipeId) {
     }));
 }
 
-export { getRecipes, getRecipe, deleteRecipe };
+function postRecipe(recipe) {
+  return (client
+    .post('/recipes',
+      { recipe },
+    ));
+}
+
+export { getRecipes, getRecipe, deleteRecipe, postRecipe };

--- a/app/javascript/components/recipes/new/create-recipes.vue
+++ b/app/javascript/components/recipes/new/create-recipes.vue
@@ -25,18 +25,21 @@
         id="name"
         :placeholder="$t('msg.recipes.name')"
         :search-icon="false"
+        v-model="recipe.name"
         class="col-span-2 w-full mx-1 my-4 p-2 border-2 rounded border-gray-300"
       >
       <input
         id="portions"
         :placeholder="$t('msg.recipes.portions')"
         :search-icon="false"
+        v-model="recipe.portions"
         class="w-full mx-1 my-4 p-2 border-2 rounded border-gray-300"
       >
       <input
         id="preparation"
         :placeholder="$t('msg.recipes.preparation')"
         :search-icon="false"
+        v-model="recipe.cook_minutes"
         class="w-full mx-1 my-4 p-2 border-2 rounded border-gray-200 border-gray-300"
       >
     </div>
@@ -78,6 +81,7 @@
 </template>
 
 <script>
+import postRecipe from '../../../api/recipes.js';
 import List from './list.vue';
 
 export default {
@@ -89,21 +93,40 @@ export default {
   },
   data() {
     return {
+      recipe: {
+        name: '',
+        portions: '',
+        cook_minutes: '', // eslint-disable-line camelcase
+        steps_attributes: [], // eslint-disable-line camelcase
+      },
       steps: [],
+      error: '',
     };
   },
   methods: {
-    create() {
-      const name = document.getElementById('name').value;
-      const portions = document.getElementById('portions').value;
-      const preparation = document.getElementById('preparation').value;
-      if (name === '' || portions === '' || preparation === '') {
+    async create() {
+      if (this.recipe.name === '' || this.recipe.portions === '' || this.recipe.preparation === '') {
         alert(this.$t('msg.recipes.alertEmptyStep')); // eslint-disable-line no-alert
+
+        return false;
       }
-      console.log(name, portions, preparation);
+
+      try {
+        const data = await postRecipe(this.recipe);
+        console.log(data);
+      } catch (error) {
+        this.error = error;
+        console.log(error);
+      }
+      console.log(this.recipe);
+
+      return null;
     },
     addStep(step) {
-      this.steps.push(step);
+      this.recipe.steps_attributes.push({
+        description: step,
+        media_url: 'https://media_url', // eslint-disable-line camelcase
+      });
     },
   },
   computed: {

--- a/app/javascript/components/recipes/new/create-recipes.vue
+++ b/app/javascript/components/recipes/new/create-recipes.vue
@@ -81,8 +81,8 @@
 </template>
 
 <script>
-import postRecipe from '../../../api/recipes.js';
 import List from './list.vue';
+import { postRecipe } from '../../../api/recipes.js';
 
 export default {
   components: {
@@ -110,15 +110,12 @@ export default {
 
         return false;
       }
-
       try {
-        const data = await postRecipe(this.recipe);
-        console.log(data);
+        await postRecipe(this.recipe);
+        window.location = '/recipes';
       } catch (error) {
         this.error = error;
-        console.log(error);
       }
-      console.log(this.recipe);
 
       return null;
     },

--- a/app/javascript/components/recipes/new/create-recipes.vue
+++ b/app/javascript/components/recipes/new/create-recipes.vue
@@ -22,16 +22,19 @@
 
     <div class="grid grid-cols-4 gap-4">
       <input
+        id="name"
         :placeholder="$t('msg.recipes.name')"
         :search-icon="false"
         class="col-span-2 w-full mx-1 my-4 p-2 border-2 rounded border-gray-300"
       >
       <input
+        id="portions"
         :placeholder="$t('msg.recipes.portions')"
         :search-icon="false"
         class="w-full mx-1 my-4 p-2 border-2 rounded border-gray-300"
       >
       <input
+        id="preparation"
         :placeholder="$t('msg.recipes.preparation')"
         :search-icon="false"
         class="w-full mx-1 my-4 p-2 border-2 rounded border-gray-200 border-gray-300"
@@ -57,6 +60,7 @@
           :svg="{sixdots: true, cancel: false, menu_recipe: true, dropdown: true}"
           :input="false"
           :drag="true"
+          @update="addStep"
         />
       </div>
     </div>
@@ -83,9 +87,23 @@ export default {
   props: {
     objects: { type: Array, required: true },
   },
+  data() {
+    return {
+      steps: [],
+    };
+  },
   methods: {
     create() {
-      return null;
+      const name = document.getElementById('name').value;
+      const portions = document.getElementById('portions').value;
+      const preparation = document.getElementById('preparation').value;
+      if (name === '' || portions === '' || preparation === '') {
+        alert(this.$t('msg.recipes.alertEmptyStep')); // eslint-disable-line no-alert
+      }
+      console.log(name, portions, preparation);
+    },
+    addStep(step) {
+      this.steps.push(step);
     },
   },
   computed: {

--- a/app/javascript/components/recipes/new/list.vue
+++ b/app/javascript/components/recipes/new/list.vue
@@ -113,13 +113,16 @@ export default {
     },
     addStep() {
       const text = document.getElementById('textarea');
-      if (this.steps.includes(text.value) === false) {
+      if (text.value === '') {
+        alert(this.$t('msg.recipes.alertEmptyStep')); // eslint-disable-line no-alert
+      } else if (this.steps.includes(text.value) === false) {
         this.steps.push(text.value);
+        this.$emit('update', text.value);
         text.value = '';
         this.forceUpdate = true;
         this.$forceUpdate();
       } else {
-        alert(this.$t('msg.recipes.alert')); // eslint-disable-line no-alert
+        alert(this.$t('msg.recipes.alertExistingStep')); // eslint-disable-line no-alert
       }
     },
     deleteStep(originalText) {

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -72,7 +72,8 @@ export default {
         aply: 'Aplicar',
         delete: 'Borrar filtro',
       },
-      alert: 'Ese paso ya existe',
+      alertExistingStep: 'Ese paso ya existe',
+      alertEmptyStep: 'Ingresa información al paso',
     },
 
     menus: {


### PR DESCRIPTION
# Lo que se hizo

- Agregar backend para agregar recetas, considerando sólo el nombre, tiempo de preparación, porciones y pasos de la receta.

# QA

- Entrar a recipes/new
- Crear una receta, ignorando la parte de los ingredientes. Agregar pasos, nombre y otras cosas. En caso de no agregar alguno de los campos, la página debería alertar.
- Después de creada la receta, la página debe redirigir a la página principal de recetas, donde se debe ver la receta recién creada. Entrar y comprobar que la información sea correcta.

# Que falta

- Agregar la parte de ingredientes al backend