### PR TITLE
feat(api): complete nested resources

### DIFF
--- a/app/controllers/api/v1/menus_controller.rb
+++ b/app/controllers/api/v1/menus_controller.rb
@@ -43,7 +43,7 @@ class Api::V1::MenusController < Api::V1::BaseController
   def menu_params
     params.require(:menu).permit(
       :name,
-      menu_recipes_attributes: [:recipe_id, :recipe_quantity]
+      menu_recipes_attributes: [:id, :recipe_id, :recipe_quantity, :_destroy]
     )
   end
 end

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -36,6 +36,7 @@ class Api::V1::RecipesController < Api::V1::BaseController
       :name,
       :portions,
       :cook_minutes,
+      recipe_ingredients_attributes: [:id, :ingredient_id, :ingredient_quantity, :_destroy],
       steps_attributes: [:description, :media_url]
     )
   end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -2,7 +2,7 @@ class Menu < ApplicationRecord
   belongs_to :user
   has_many :menu_recipes, dependent: :destroy
   has_many :recipes, through: :menu_recipes, dependent: nil
-  accepts_nested_attributes_for :menu_recipes
+  accepts_nested_attributes_for :menu_recipes, allow_destroy: true
 end
 
 # == Schema Information

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -6,6 +6,7 @@ class Recipe < ApplicationRecord
   has_many :ingredients, through: :recipe_ingredients, dependent: nil
   has_many :steps, dependent: :destroy, class_name: "RecipeStep"
   accepts_nested_attributes_for :steps
+  accepts_nested_attributes_for :recipe_ingredients, allow_destroy: true
 end
 
 # == Schema Information

--- a/spec/integration/api/v1/menus_spec.rb
+++ b/spec/integration/api/v1/menus_spec.rb
@@ -109,7 +109,7 @@ describe 'Api::V1::Menus', swagger_doc: 'v1/swagger.json' do
         schema: {
           type: "object",
           properties: {
-            menu: { "$ref" => "#/definitions/menu" }
+            menu: { "$ref" => "#/definitions/menu_update" }
           },
           required: [
             :menu

--- a/spec/integration/api/v1/recipes_spec.rb
+++ b/spec/integration/api/v1/recipes_spec.rb
@@ -113,7 +113,7 @@ describe 'Api::V1::Recipes', swagger_doc: 'v1/swagger.json' do
                 schema: {
                   type: "object",
                   properties: {
-                    recipe: { "$ref" => "#/definitions/recipe" }
+                    recipe: { "$ref" => "#/definitions/recipe_update" }
                   },
                   required: [
                     :recipe

--- a/spec/swagger/v1/definition.rb
+++ b/spec/swagger/v1/definition.rb
@@ -31,10 +31,12 @@ API_V1 = {
     providers_collection: PROVIDERS_COLLECTION_SCHEMA,
     provider_resource: PROVIDER_RESOURCE_SCHEMA,
     menu: MENU_SCHEMA,
+    menu_update: MENU_UPDATE_SCHEMA,
     menu_response: MENU_RESPONSE_SCHEMA,
     menus_collection: MENUS_COLLECTION_SCHEMA,
     menu_resource: MENU_RESOURCE_SCHEMA,
     recipe: RECIPE_SCHEMA,
+    recipe_update: RECIPE_UPDATE_SCHEMA,
     recipes_collection: RECIPES_COLLECTION_SCHEMA,
     recipe_resource: RECIPE_RESOURCE_SCHEMA,
     recipe_response: RECIPE_RESPONSE_SCHEMA

--- a/spec/swagger/v1/schemas/menu_schema.rb
+++ b/spec/swagger/v1/schemas/menu_schema.rb
@@ -18,6 +18,28 @@ MENU_SCHEMA = {
   ]
 }
 
+MENU_UPDATE_SCHEMA = {
+  type: :object,
+  properties: {
+    name: { type: :string, example: 'Menú de almuerzo', 'x-nullable': true },
+    menu_recipes_attributes: {
+      type: "array",
+      items: {
+        type: :object,
+        properties: {
+          id: { type: :integer, example: 1, 'x-nullable': true },
+          recipe_id: { type: :integer, example: 1, 'x-nullable': false },
+          recipe_quantity: { type: :integer, example: 5, 'x-nullable': true },
+          _destroy: { type: :boolean, example: false, 'x-nullable': true }
+        }
+      }
+    }
+  },
+  required: [
+    :name
+  ]
+}
+
 MENU_RESPONSE_SCHEMA = {
   type: :object,
   properties: {

--- a/spec/swagger/v1/schemas/recipe_schema.rb
+++ b/spec/swagger/v1/schemas/recipe_schema.rb
@@ -4,6 +4,52 @@ RECIPE_SCHEMA = {
     name: { type: :string, example: 'Pastel de choclo', 'x-nullable': true },
     portions: { type: :integer, example: 4, 'x-nullable': true },
     cook_minutes: { type: :integer, example: 25, 'x-nullable': true },
+    recipe_ingredients_attributes: {
+      type: "array",
+      items: {
+        type: :object,
+        properties: {
+          ingredient_id: { type: :integer, example: 2, 'x-nullable': false },
+          ingredient_quantity: { type: :integer, example: 5, 'x-nullable': false }
+        }
+      }
+    },
+    steps_attributes: {
+      type: "array",
+      items: {
+        type: :object,
+        properties: {
+          description: { type: :string, example: 'Horneamos la masa', 'x-nullable': false },
+          media_url: { type: :string, example: 'https://media-url', 'x-nullable': true }
+        }
+      }
+    }
+  },
+  required: [
+    :name,
+    :portions,
+    :cook_minutes
+  ]
+}
+
+RECIPE_UPDATE_SCHEMA = {
+  type: :object,
+  properties: {
+    name: { type: :string, example: 'Pastel de choclo', 'x-nullable': true },
+    portions: { type: :integer, example: 4, 'x-nullable': true },
+    cook_minutes: { type: :integer, example: 25, 'x-nullable': true },
+    recipe_ingredients_attributes: {
+      type: "array",
+      items: {
+        type: :object,
+        properties: {
+          id: { type: :integer, example: 1, 'x-nullable': true },
+          ingredient_id: { type: :integer, example: 2, 'x-nullable': false },
+          ingredient_quantity: { type: :integer, example: 5, 'x-nullable': false },
+          _destroy: { type: :boolean, example: false, 'x-nullable': true }
+        }
+      }
+    },
     steps_attributes: {
       type: "array",
       items: {

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -693,6 +693,47 @@
         "name"
       ]
     },
+    "menu_update": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "Menú de almuerzo",
+          "x-nullable": true
+        },
+        "menu_recipes_attributes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "example": 1,
+                "x-nullable": true
+              },
+              "recipe_id": {
+                "type": "integer",
+                "example": 1,
+                "x-nullable": false
+              },
+              "recipe_quantity": {
+                "type": "integer",
+                "example": 5,
+                "x-nullable": true
+              },
+              "_destroy": {
+                "type": "boolean",
+                "example": false,
+                "x-nullable": true
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
     "menu_response": {
       "type": "object",
       "properties": {
@@ -785,6 +826,95 @@
           "type": "integer",
           "example": 25,
           "x-nullable": true
+        },
+        "recipe_ingredients_attributes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "ingredient_id": {
+                "type": "integer",
+                "example": 2,
+                "x-nullable": false
+              },
+              "ingredient_quantity": {
+                "type": "integer",
+                "example": 5,
+                "x-nullable": false
+              }
+            }
+          }
+        },
+        "steps_attributes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string",
+                "example": "Horneamos la masa",
+                "x-nullable": false
+              },
+              "media_url": {
+                "type": "string",
+                "example": "https://media-url",
+                "x-nullable": true
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "name",
+        "portions",
+        "cook_minutes"
+      ]
+    },
+    "recipe_update": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "Pastel de choclo",
+          "x-nullable": true
+        },
+        "portions": {
+          "type": "integer",
+          "example": 4,
+          "x-nullable": true
+        },
+        "cook_minutes": {
+          "type": "integer",
+          "example": 25,
+          "x-nullable": true
+        },
+        "recipe_ingredients_attributes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "example": 1,
+                "x-nullable": true
+              },
+              "ingredient_id": {
+                "type": "integer",
+                "example": 2,
+                "x-nullable": false
+              },
+              "ingredient_quantity": {
+                "type": "integer",
+                "example": 5,
+                "x-nullable": false
+              },
+              "_destroy": {
+                "type": "boolean",
+                "example": false,
+                "x-nullable": true
+              }
+            }
+          }
         },
         "steps_attributes": {
           "type": "array",
@@ -1478,7 +1608,7 @@
               "type": "object",
               "properties": {
                 "menu": {
-                  "$ref": "#/definitions/menu"
+                  "$ref": "#/definitions/menu_update"
                 }
               },
               "required": [
@@ -2066,7 +2196,7 @@
               "type": "object",
               "properties": {
                 "recipe": {
-                  "$ref": "#/definitions/recipe"
+                  "$ref": "#/definitions/recipe_update"
                 }
               },
               "required": [


### PR DESCRIPTION
### Contexto

Dada la interfaz de Figma, preferimos finalmente utilizar una sola request al momento de crear/editar una receta o menú, usando los principios que provee Rails para nested resources.

### Qué hice 

Ahora tanto recetas (con sus ingredientes) y menús (con sus recetas) pueden trabajar con una sola request que tenga todos los datos.

Funciona de la siguiente forma:
- Inicialmente, al crear con un POST, solo se pasan los ids y las cantidades. Por ejemplo, para recetas:
![image](https://user-images.githubusercontent.com/30879716/119896727-6e3e7880-bf0d-11eb-9782-bece86444d07.png)

- Luego, para editar o eliminar, se debe pasar lo mismo, pero con el ID del nested resource:
![image](https://user-images.githubusercontent.com/30879716/119896790-84e4cf80-bf0d-11eb-9fc1-d0a6c4b5ab43.png)

Aquí vemos varias cosas. 

Si no estuviera el nombre de la receta, esta no se actualiza. Si no estuvieran los `recipe_ingredients_attributes`, entonces tampoco nada pasaría. 

Si el `recipe_ingredients_attributes` contiene únicamente datos del ID y la cantidad, entonces **se agrega un nuevo ingrediente**. 

Si queremos editar uno específico, debemos pasar el ID de la relación y cambiar los atributos, pasar `_destroy: false`. 
Si queremos eliminarla, debemos pasar los atributos incluído el ID más el `_destroy: true`.