### PR TITLE
feat(api): add measures model

### DIFF
--- a/app/controllers/api/v1/ingredients_controller.rb
+++ b/app/controllers/api/v1/ingredients_controller.rb
@@ -65,10 +65,9 @@ class Api::V1::IngredientsController < Api::V1::BaseController
       :sku,
       :price,
       :currency,
-      :quantity,
-      :measure,
       :inventory,
-      :provider_name
+      :provider_name,
+      ingredient_measures_attributes: [:name, :quantity]
     )
   end
 end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -3,12 +3,26 @@ class Ingredient < ApplicationRecord
   belongs_to :provider, optional: true
   has_many :recipe_ingredients, dependent: :destroy
   has_many :recipes, through: :recipe_ingredients, dependent: nil
+  has_many :ingredient_measures, dependent: :destroy
+  accepts_nested_attributes_for :ingredient_measures
 
   validates :inventory, numericality: { greater_than_or_equal_to: 0 }
 
   def decrement_inventory!(quantity_to_decrement)
     final_inventory = [inventory - quantity_to_decrement, 0].max
     update!(inventory: final_inventory)
+  end
+
+  def measure
+    default_measure&.name
+  end
+
+  def quantity
+    default_measure&.quantity
+  end
+
+  def default_measure
+    ingredient_measures.first
   end
 end
 
@@ -23,8 +37,6 @@ end
 #  sku         :string
 #  price       :integer
 #  currency    :string
-#  quantity    :integer
-#  measure     :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  inventory   :integer          default(0)

--- a/app/models/ingredient_measure.rb
+++ b/app/models/ingredient_measure.rb
@@ -1,0 +1,23 @@
+class IngredientMeasure < ApplicationRecord
+  belongs_to :ingredient
+end
+
+# == Schema Information
+#
+# Table name: ingredient_measures
+#
+#  id            :bigint(8)        not null, primary key
+#  quantity      :integer
+#  ingredient_id :bigint(8)        not null
+#  name          :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_ingredient_measures_on_ingredient_id  (ingredient_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (ingredient_id => ingredients.id)
+#

--- a/app/serializers/api/v1/ingredient_measure_serializer.rb
+++ b/app/serializers/api/v1/ingredient_measure_serializer.rb
@@ -1,0 +1,8 @@
+class Api::V1::IngredientMeasureSerializer < ActiveModel::Serializer
+  type :ingredient_measure
+
+  attributes(
+    :name,
+    :quantity
+  )
+end

--- a/app/serializers/api/v1/ingredient_serializer.rb
+++ b/app/serializers/api/v1/ingredient_serializer.rb
@@ -11,7 +11,14 @@ class Api::V1::IngredientSerializer < ActiveModel::Serializer
     :quantity,
     :measure,
     :inventory,
+    :other_measures,
     :created_at,
     :updated_at
   )
+
+  def other_measures
+    ActiveModelSerializers::SerializableResource.new(
+      object.ingredient_measures, each_serializer: Api::V1::IngredientMeasureSerializer
+    )
+  end
 end

--- a/app/serializers/api/v1/recipe_ingredient_serializer.rb
+++ b/app/serializers/api/v1/recipe_ingredient_serializer.rb
@@ -7,4 +7,8 @@ class Api::V1::RecipeIngredientSerializer < ActiveModel::Serializer
     :created_at,
     :updated_at
   )
+
+  def ingredient
+    Api::V1::IngredientSerializer.new(object.ingredient)
+  end
 end

--- a/db/migrate/20210530181433_create_ingredient_measures.rb
+++ b/db/migrate/20210530181433_create_ingredient_measures.rb
@@ -1,0 +1,11 @@
+class CreateIngredientMeasures < ActiveRecord::Migration[6.0]
+  def change
+    create_table :ingredient_measures do |t|
+      t.integer :quantity
+      t.references :ingredient, null: false, foreign_key: true
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210530185458_remove_columns_from_ingredients.rb
+++ b/db/migrate/20210530185458_remove_columns_from_ingredients.rb
@@ -1,0 +1,6 @@
+class RemoveColumnsFromIngredients < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured { remove_column :ingredients, :quantity, :integer }
+    safety_assured { remove_column :ingredients, :measure, :string }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,6 +43,15 @@ ActiveRecord::Schema.define(version: 2021_06_10_220621) do
                                       unique: true
   end
 
+  create_table "ingredient_measures", force: :cascade do |t|
+    t.integer "quantity"
+    t.bigint "ingredient_id", null: false
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["ingredient_id"], name: "index_ingredient_measures_on_ingredient_id"
+  end
+
   create_table "ingredients", force: :cascade do |t|
     t.bigint "provider_id"
     t.bigint "user_id", null: false
@@ -50,8 +59,6 @@ ActiveRecord::Schema.define(version: 2021_06_10_220621) do
     t.string "sku"
     t.integer "price"
     t.string "currency"
-    t.integer "quantity"
-    t.string "measure"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "inventory", default: 0
@@ -137,6 +144,7 @@ ActiveRecord::Schema.define(version: 2021_06_10_220621) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "ingredient_measures", "ingredients"
   add_foreign_key "ingredients", "providers"
   add_foreign_key "ingredients", "users"
   add_foreign_key "menu_recipes", "menus"

--- a/db/seeds/ingredients.rb
+++ b/db/seeds/ingredients.rb
@@ -1,72 +1,101 @@
+provider1 = Provider.first
+provider2 = Provider.second
 
-provider_1 = Provider.first
-provider_2 = Provider.second
+user1 = User.first
+user2 = User.second
 
-user_1 = User.first
-user_2 = User.second
-
-Ingredient.create(
-  provider_id: provider_1.id,
-  user_id: user_1.id,
+ingredient1 = Ingredient.create(
+  provider_id: provider1.id,
+  user_id: user1.id,
   name: 'Harina',
   sku: '98412312',
   price: 2990,
-  currency: 'CLP',
-  quantity: 1,
-  measure: 'Kg'
+  currency: 'CLP'
 )
 
-Ingredient.create(
-  provider_id: provider_2.id,
-  user_id: user_1.id,
+ingredient2 = Ingredient.create(
+  provider_id: provider2.id,
+  user_id: user1.id,
   name: 'Huevos',
   sku: '98417912',
   price: 3990,
-  currency: 'CLP',
-  quantity: 1,
-  measure: 'Unidades'
+  currency: 'CLP'
 )
 
-Ingredient.create(
-  provider_id: provider_1.id,
-  user_id: user_1.id,
+ingredient3 = Ingredient.create(
+  provider_id: provider1.id,
+  user_id: user1.id,
   name: 'Manjar',
   sku: '98416584',
   price: 4290,
-  currency: 'CLP',
-  quantity: 1,
-  measure: 'Kg'
+  currency: 'CLP'
 )
 
-Ingredient.create(
-  provider_id: provider_1.id,
-  user_id: user_2.id,
+ingredient4 = Ingredient.create(
+  provider_id: provider1.id,
+  user_id: user2.id,
   name: 'Limón',
   sku: '98412812',
   price: 990,
-  currency: 'CLP',
-  quantity: 4,
-  measure: 'Kg'
+  currency: 'CLP'
 )
 
-Ingredient.create(
-  provider_id: provider_2.id,
-  user_id: user_2.id,
+ingredient5 = Ingredient.create(
+  provider_id: provider2.id,
+  user_id: user2.id,
   name: 'Mantequilla',
   sku: '98411234',
   price: 2990,
-  currency: 'CLP',
-  quantity: 1,
-  measure: 'Kg'
+  currency: 'CLP'
 )
 
-Ingredient.create(
-  provider_id: provider_2.id,
-  user_id: user_2.id,
+ingredient6 = Ingredient.create(
+  provider_id: provider2.id,
+  user_id: user2.id,
   name: 'Sal',
   sku: '98410091',
   price: 1990,
-  currency: 'CLP',
-  quantity: 1,
-  measure: 'Kg'
+  currency: 'CLP'
+)
+
+IngredientMeasure.create(
+  ingredient_id: ingredient1.id,
+  name: 'Kg',
+  quantity: 1
+)
+
+IngredientMeasure.create(
+  ingredient_id: ingredient2.id,
+  name: 'Kg',
+  quantity: 1
+)
+
+IngredientMeasure.create(
+  ingredient_id: ingredient3.id,
+  name: 'Unidad',
+  quantity: 1
+)
+
+IngredientMeasure.create(
+  ingredient_id: ingredient4.id,
+  name: 'Malla',
+  quantity: 1
+)
+
+IngredientMeasure.create(
+  ingredient_id: ingredient4.id,
+  name: 'Kg',
+  quantity: 2
+)
+
+IngredientMeasure.create(
+  ingredient_id: ingredient5.id,
+  name: 'Gramos',
+  quantity: 500
+)
+
+IngredientMeasure.create(
+  ingredient_id: ingredient6.id,
+  name: 'Kg',
+  quantity: 1
 )

--- a/spec/factories/ingredient_measures.rb
+++ b/spec/factories/ingredient_measures.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :ingredient_measure do
+    quantity { 1 }
+    ingredient { create(:ingredient) }
+    name { "L" }
+  end
+end

--- a/spec/factories/ingredients.rb
+++ b/spec/factories/ingredients.rb
@@ -4,8 +4,6 @@ FactoryBot.define do
     sku { Faker::Alphanumeric.alphanumeric(number: 10) }
     price { rand(50..300) * 10 }
     currency { "CLP" }
-    quantity { rand(1..3) }
-    measure { "kg" }
     user { create(:user) }
   end
 end

--- a/spec/integration/api/v1/ingredients_spec.rb
+++ b/spec/integration/api/v1/ingredients_spec.rb
@@ -226,7 +226,13 @@ describe 'API::V1::Ingredients', swagger_doc: 'v1/swagger.json' do
             currency: 'Some currency',
             quantity: 666,
             measure: 'Some measure',
-            inventory: 25
+            inventory: 25,
+            ingredient_measures_attributes: [
+              {
+                name: 'Kg',
+                quantity: 1
+              }
+            ]
           }
         end
 
@@ -298,8 +304,6 @@ describe 'API::V1::Ingredients', swagger_doc: 'v1/swagger.json' do
             sku: 'Some sku',
             price: 666,
             currency: 'Some currency',
-            quantity: 666,
-            measure: 'Some measure',
             inventory: 15
           }
         end

--- a/spec/models/ingredient_measure_spec.rb
+++ b/spec/models/ingredient_measure_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe IngredientMeasure, type: :model do
+  let(:ingredient_measure) { build(:ingredient_measure) }
+
+  it { is_expected.to belong_to(:ingredient) }
+
+  describe 'it has all the attributes' do
+    ["name", "quantity"].each do |attribute|
+      it "includes the #{attribute} attribute" do
+        expect(ingredient_measure.attributes).to include(attribute)
+      end
+    end
+
+    it "succeeds on save" do
+      expect(ingredient_measure.save!).to be(true)
+    end
+  end
+
+  describe "without ingredient" do
+    let(:ingredient_measure) { build(:ingredient_measure, ingredient: nil) }
+
+    it "raises RecordInvalid exception" do
+      expect { ingredient_measure.save! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+end

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Ingredient, type: :model do
   it { is_expected.to have_many(:recipes).through(:recipe_ingredients) }
 
   describe 'it has all the attributes' do
-    ["name", "sku", "price", "currency", "quantity", "measure"].each do |attribute|
+    ["name", "sku", "price", "currency"].each do |attribute|
       it "includes the #{attribute} attribute" do
         expect(ingredient.attributes).to include(attribute)
       end

--- a/spec/swagger/v1/definition.rb
+++ b/spec/swagger/v1/definition.rb
@@ -39,6 +39,7 @@ API_V1 = {
     recipe_update: RECIPE_UPDATE_SCHEMA,
     recipes_collection: RECIPES_COLLECTION_SCHEMA,
     recipe_resource: RECIPE_RESOURCE_SCHEMA,
-    recipe_response: RECIPE_RESPONSE_SCHEMA
+    recipe_response: RECIPE_RESPONSE_SCHEMA,
+    ingredient_measure_response: INGREDIENT_MEASURE_SCHEMA
   }
 }

--- a/spec/swagger/v1/schemas/ingredient_measure_schema.rb
+++ b/spec/swagger/v1/schemas/ingredient_measure_schema.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+INGREDIENT_MEASURE_SCHEMA = {
+  type: :object,
+  properties: {
+    name: { type: :string, example: 'unidad' },
+    quantity: { type: :integer, example: 2 }
+  }
+}

--- a/spec/swagger/v1/schemas/ingredient_schema.rb
+++ b/spec/swagger/v1/schemas/ingredient_schema.rb
@@ -6,9 +6,17 @@ INGREDIENT_SCHEMA = {
     sku: { type: :string, example: 'SK28CD2', 'x-nullable': true },
     price: { type: :integer, example: 2990, 'x-nullable': true },
     currency: { type: :string, example: 'CLP', 'x-nullable': true },
-    quantity: { type: :integer, example: 2, 'x-nullable': true },
-    measure: { type: :string, example: 'unidad', 'x-nullable': true },
-    inventory: { type: :integer, example: 10, 'x-nullable': true }
+    inventory: { type: :integer, example: 10, 'x-nullable': true },
+    ingredient_measures_attributes: {
+      type: "array",
+      items: {
+        type: :object,
+        properties: {
+          name: { type: :string, example: 'Kg', 'x-nullable': false },
+          quantity: { type: :integer, example: 1, 'x-nullable': true }
+        }
+      }
+    }
   },
   required: [
     :name,
@@ -36,6 +44,15 @@ INGREDIENT_RESPONSE_SCHEMA = {
         quantity: { type: :integer, example: 2, 'x-nullable': true },
         measure: { type: :string, example: 'unidad', 'x-nullable': true },
         inventory: { type: :integer, example: 10, 'x-nullable': true },
+        measures: {
+          type: "object",
+          properties: {
+            data: {
+              type: "array",
+              items: { "$ref" => "#/definitions/ingredient_measure_response" }
+            }
+          }
+        },
         created_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
         updated_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true }
       },

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -44,7 +44,9 @@
               "x-nullable": true
             }
           },
-          "required": []
+          "required": [
+
+          ]
         }
       },
       "required": [
@@ -131,7 +133,9 @@
               "x-nullable": true
             }
           },
-          "required": []
+          "required": [
+
+          ]
         }
       },
       "required": [
@@ -240,7 +244,9 @@
               "x-nullable": true
             }
           },
-          "required": []
+          "required": [
+
+          ]
         }
       },
       "required": [
@@ -397,20 +403,28 @@
           "example": "CLP",
           "x-nullable": true
         },
-        "quantity": {
-          "type": "integer",
-          "example": 2,
-          "x-nullable": true
-        },
-        "measure": {
-          "type": "string",
-          "example": "unidad",
-          "x-nullable": true
-        },
         "inventory": {
           "type": "integer",
           "example": 10,
           "x-nullable": true
+        },
+        "ingredient_measures_attributes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "example": "Kg",
+                "x-nullable": false
+              },
+              "quantity": {
+                "type": "integer",
+                "example": 1,
+                "x-nullable": true
+              }
+            }
+          }
         }
       },
       "required": [
@@ -480,6 +494,17 @@
               "example": 10,
               "x-nullable": true
             },
+            "measures": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/ingredient_measure_response"
+                  }
+                }
+              }
+            },
             "created_at": {
               "type": "string",
               "example": "1984-06-04 09:00",
@@ -491,7 +516,9 @@
               "x-nullable": true
             }
           },
-          "required": []
+          "required": [
+
+          ]
         }
       },
       "required": [
@@ -638,7 +665,9 @@
               "x-nullable": true
             }
           },
-          "required": []
+          "required": [
+
+          ]
         }
       },
       "required": [
@@ -795,7 +824,9 @@
               }
             }
           },
-          "required": []
+          "required": [
+
+          ]
         }
       },
       "required": [
@@ -1068,7 +1099,9 @@
               }
             }
           },
-          "required": []
+          "required": [
+
+          ]
         }
       },
       "required": [
@@ -1076,6 +1109,19 @@
         "type",
         "attributes"
       ]
+    },
+    "ingredient_measure_response": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "unidad"
+        },
+        "quantity": {
+          "type": "integer",
+          "example": 2
+        }
+      }
     }
   },
   "paths": {


### PR DESCRIPTION
### Contexto

Se ven hartos archivos pero puros cambios chicos 🙂 

La idea con esto es que podamos usar distintas medidas para cada ingrediente, y así poder transformar cuando queramos haciendo la transformación a precio. Al momento de crear un ingrediente se deberá elegir >= 1 medida para cada ingrediente, y luego se podrá elegir cuál usar.

### Qué hice

Creé el modelo `IngredientMeasure` y eliminé los atributos `measure` y `quantity`. 
Por ahora solo se pueden agregar junto al ingrediente (pasándolo nested). Dejé el atributo `measure` y `quantity` aparte del nuevo `measures`, donde los primeros son los "por default": el primero de la lista de `measures`. Para el tema de la conversión de precios, creo que es más fácil hacerlo en frontend que pasarlo directamente calculado, porque todo depende del único precio del ingrediente.

### Falta

- [x] Modificar frontend para crear las `measures` de forma nested en vez de pasar los atributos. Añadir más medidas y poder hacer el cambio entre ellas cambiando el precio.
- [x] Modificar mobile para crear las `measures` de forma nested en vez de pasar los atributos. Añadir más medidas y poder hacer el cambio entre ellas cambiando el precio.

### Futuro
- [x] Agregar columna a la tabla de `RecipeIngredient` para que pueda seleccionar una de las `RecipeMeasures` y se guarde en esta tabla. Por ahora solo se está guardando `ingredient_quantity`, por lo que faltaría el `ingredient_measure` y que se pueda pasar en la request
- [x] Poder cambiar, eliminar, editar cada una de las medidas para cada ingrediente con endpoints específicos.

POST:

![image](https://user-images.githubusercontent.com/30879716/120117462-4b090880-c15b-11eb-9813-14dfdb9acf9b.png)


GET:

![image](https://user-images.githubusercontent.com/30879716/120117473-58be8e00-c15b-11eb-845c-12da00b084e7.png)
