### PR TITLE
fix(dropdown): change dropdown time to close

### DIFF
--- a/app/javascript/components/base/dots-dropdown.vue
+++ b/app/javascript/components/base/dots-dropdown.vue
@@ -49,9 +49,11 @@ export default {
     },
     editIngredient() {
       this.$emit('edit');
+      this.active = !this.active;
     },
     deleteIngredient() {
       this.$emit('del');
+      this.active = !this.active;
     },
   },
 };

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_05_26_031702) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,11 +24,9 @@ ActiveRecord::Schema.define(version: 2021_05_26_031702) do
     t.bigint "author_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["author_type", "author_id"],
-            name: "index_active_admin_comments_on_author_type_and_author_id"
+    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
     t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
-    t.index ["resource_type", "resource_id"],
-            name: "index_active_admin_comments_on_resource_type_and_resource_id"
+    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"
   end
 
   create_table "admin_users", force: :cascade do |t|
@@ -39,8 +38,7 @@ ActiveRecord::Schema.define(version: 2021_05_26_031702) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token",
-                                      unique: true
+    t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 
   create_table "ingredients", force: :cascade do |t|


### PR DESCRIPTION
### Lo que se hizo ### 
Se arreglo tema de que los dropdowns no queden abiertos para siempre

### QA ###

Para probar el funcionamiento debe pararse en esta rama, correr rails s e ir a /ingredients o /menus y probar que al apretar los 3 puntitos se abre un dropdown y al seleccionar alguna opcion de este, el dropdown se cierra

### Falta ### 
Arreglar el tema de poder cerrar un modal al apretar en cualquier lugar fuera de este