### PR TITLE
feat(create-recipe): send recipe ingredients nested

### DIFF
--- a/app/javascript/components/recipes/new/container.vue
+++ b/app/javascript/components/recipes/new/container.vue
@@ -9,7 +9,7 @@
       >
         <div class="justify-self-start">
           <input
-            v-model="element.ingredientQuantity"
+            v-model="ingredient.ingredientQuantity"
             class="w-16 h-12 self-center bg-white text-gray-700
             border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none"
             v-if="input"
@@ -125,6 +125,7 @@ export default {
   data() {
     return {
       edit: false,
+      ingredient: this.element,
     };
   },
   methods: {

--- a/app/javascript/components/recipes/new/container.vue
+++ b/app/javascript/components/recipes/new/container.vue
@@ -9,6 +9,7 @@
       >
         <div class="justify-self-start">
           <input
+            v-model="element.ingredientQuantity"
             class="w-16 h-12 self-center bg-white text-gray-700
             border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none"
             v-if="input"

--- a/app/javascript/components/recipes/new/create-recipes.vue
+++ b/app/javascript/components/recipes/new/create-recipes.vue
@@ -128,6 +128,7 @@ export default {
         portions: '',
         cook_minutes: '', // eslint-disable-line camelcase
         steps_attributes: [], // eslint-disable-line camelcase
+        recipe_ingredients_attributes: [], // eslint-disable-line camelcase
       },
       steps: [],
       error: '',
@@ -156,6 +157,12 @@ export default {
 
         return false;
       }
+      this.ingredients.forEach(ingredient => {
+        this.recipe.recipe_ingredients_attributes.push({
+          "ingredient_id": ingredient.id,
+          "ingredient_quantity": ingredient.ingredientQuantity,
+        });
+      });
       try {
         await postRecipe(this.recipe);
         window.location = '/recipes';

--- a/app/javascript/components/recipes/new/create-recipes.vue
+++ b/app/javascript/components/recipes/new/create-recipes.vue
@@ -159,8 +159,8 @@ export default {
       }
       this.ingredients.forEach(ingredient => {
         this.recipe.recipe_ingredients_attributes.push({
-          "ingredient_id": ingredient.id,
-          "ingredient_quantity": ingredient.ingredientQuantity,
+          'ingredient_id': ingredient.id,
+          'ingredient_quantity': ingredient.ingredientQuantity,
         });
       });
       try {


### PR DESCRIPTION
# Que se hizo
Ahora al crear una receta, al igual que los pasos, los ingredientes se mandan nested.
# QA
Se debe crear una receta y añadir ingredientes en ella. Al momento de guardarla en la view de la receta se deberían ver los ingredientes con las cantidades especificadas al momento de crearla.
# Falta por hacer
Dejar seleccionar la unidad al momento de crear receta (dentro de las unidades posibles para cada ingrediente).