### PR TITLE
feat(api@menu): add ingredients to nested menu get

### DIFF
--- a/app/serializers/api/v1/menu_recipe_serializer.rb
+++ b/app/serializers/api/v1/menu_recipe_serializer.rb
@@ -2,9 +2,13 @@ class Api::V1::MenuRecipeSerializer < ActiveModel::Serializer
   type :menu_recipe
 
   attributes(
-    :recipe,
     :recipe_quantity,
+    :recipe,
     :created_at,
     :updated_at
   )
+
+  def recipe
+    Api::V1::RecipeSerializer.new(object.recipe)
+  end
 end

--- a/spec/swagger/v1/schemas/menu_recipe_schema.rb
+++ b/spec/swagger/v1/schemas/menu_recipe_schema.rb
@@ -15,8 +15,8 @@ MENU_RECIPE_RESPONSE = {
       type: :object,
       properties: {
         menu_id: { type: :integer, example: 1, 'x-nullable': false },
-        recipe: { "$ref" => "#/definitions/recipe_response" },
         recipe_quantity: { type: :integer, example: 3, 'x-nullable': true },
+        recipe: { "$ref" => "#/definitions/recipe_response" },
         created_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true },
         updated_at: { type: :string, example: '1984-06-04 09:00', 'x-nullable': true }
       },

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -25,13 +25,13 @@
               "example": 1,
               "x-nullable": false
             },
-            "recipe": {
-              "$ref": "#/definitions/recipe_response"
-            },
             "recipe_quantity": {
               "type": "integer",
               "example": 3,
               "x-nullable": true
+            },
+            "recipe": {
+              "$ref": "#/definitions/recipe_response"
             },
             "created_at": {
               "type": "string",


### PR DESCRIPTION
Antes retornabamos las recetas peladas de un menu, sin sus ingredientes, entonces no se podía calcular el precio del menú

Acá los agrego, al final va todo nested!