### PR TITLE
feat(frontend-/fix-new-menu-bugs): search when creating, no name on create alert and price showing on index

### DIFF
--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -103,18 +103,6 @@ export default {
   props: {
     menus: { type: Array, required: true },
   },
-  // computed: {
-  //   totalMenuPrice() {
-  //     const recipesPrices = this.selectedRecipes.map(element => ((
-  //       element.recipeIngredients.data.reduce((recipePrice, recipeIngredient) =>
-  //         recipePrice + this.getPriceOfSelectedIngredient(recipeIngredient.attributes), 0)
-  //     ) * element.quantity),
-  //     );
-
-  //     return recipesPrices.reduce((menuPrice, recipePrice) =>
-  //       menuPrice + recipePrice, 0);
-  //   },
-  // },
   methods: {
     editMenu(element) {
       this.$emit('edit', element);

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -52,7 +52,7 @@
           <p
             class="ml-2 font-medium"
           >
-            {{ 20000 | currency }}
+            {{ totalMenuPrice(menu.menuRecipes.data) | currency }}
           </p>
         </td>
         <!-- recipesQuantity -->
@@ -82,8 +82,8 @@
               edit:true,
               del:true
             }"
-            @edit="editIngredient(menu)"
-            @del="deleteIngredient(menu)"
+            @edit="editMenu(menu)"
+            @del="deleteMenu(menu)"
           />
         </td>
       </tr>
@@ -103,12 +103,46 @@ export default {
   props: {
     menus: { type: Array, required: true },
   },
+  // computed: {
+  //   totalMenuPrice() {
+  //     const recipesPrices = this.selectedRecipes.map(element => ((
+  //       element.recipeIngredients.data.reduce((recipePrice, recipeIngredient) =>
+  //         recipePrice + this.getPriceOfSelectedIngredient(recipeIngredient.attributes), 0)
+  //     ) * element.quantity),
+  //     );
+
+  //     return recipesPrices.reduce((menuPrice, recipePrice) =>
+  //       menuPrice + recipePrice, 0);
+  //   },
+  // },
   methods: {
-    editIngredient(element) {
+    editMenu(element) {
       this.$emit('edit', element);
     },
-    deleteIngredient(element) {
+    deleteMenu(element) {
       this.$emit('del', element);
+    },
+    totalMenuPrice(data) {
+      let finalPrice = 0;
+      data.forEach(element => {
+        const recipeQuantity = element.attributes.recipeQuantity;
+        const ingredients = this.calculateIngredients(element.attributes.recipe.recipeIngredients.data);
+        ingredients.forEach(ingredientPriced => {
+          finalPrice += recipeQuantity * ingredientPriced;
+        });
+      });
+
+      return finalPrice;
+    },
+    calculateIngredients(data) {
+      const returnArray = [];
+      data.forEach(element => {
+        const ingredientQuantity = element.attributes.ingredientQuantity;
+        const ingredientUnitaryPrice = element.attributes.ingredient.price / element.attributes.ingredient.quantity;
+        returnArray.push(ingredientQuantity * ingredientUnitaryPrice);
+      });
+
+      return returnArray;
     },
   },
 };

--- a/app/javascript/components/menus/new/new-menu-container.vue
+++ b/app/javascript/components/menus/new/new-menu-container.vue
@@ -35,12 +35,14 @@
                 class="flex py-2 px-12 w-96 h-16 bg-gray-50 border-2 border-gray-600 rounded self-stretch flex-grow-0 focus:outline-none"
                 :placeholder="$t('msg.recipes.search')"
                 autocomplete="off"
+                @keyup="filterRecipes"
+                v-model="searchQuery"
               >
             </div>
             <!-- available recipes -->
             <div class="flex flex-col bg-gray-200 overflow-scroll">
               <add-recipe-card
-                v-for="recipe in recipes"
+                v-for="recipe in filterRecipes"
                 :key="recipe.id"
                 :name="recipe.name"
                 :portions="recipe.portions"
@@ -121,6 +123,7 @@ export default {
       query: '',
       menuName: '',
       selectedRecipes: [],
+      searchQuery: '',
     };
   },
 
@@ -134,6 +137,16 @@ export default {
 
       return recipesPrices.reduce((menuPrice, recipePrice) =>
         menuPrice + recipePrice, 0);
+    },
+    filterRecipes() {
+      if (this.searchQuery) {
+        return this.recipes.filter(item => this.searchQuery
+          .toLowerCase()
+          .split(' ')
+          .every(text => item.name.toLowerCase().includes(text)));
+      }
+
+      return this.recipes;
     },
   },
 
@@ -175,6 +188,11 @@ export default {
     },
 
     async createMenu() {
+      if (!this.menuName) {
+        alert(this.$t('msg.menus.noNameAlert')); // eslint-disable-line no-alert
+
+        return;
+      }
       const menuRecipesToPost = this.selectedRecipes.map(element => (
         {
           recipeId: parseInt(element.id, 10),

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -113,7 +113,7 @@ export default {
       recipesQuantity: 'Cantidad de recetas',
       recipes: 'Recetas',
       noRecipes: 'Este menú aún no tiene recetas',
-      noNameAlert: 'Ingresa el nombre del menú por favor'
+      noNameAlert: 'Ingresa el nombre del menú por favor',
     },
     providers: {
       title: 'Proveedores',

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -98,7 +98,7 @@ export default {
       add: 'Agregar menú',
       edit: 'Editar menú',
       delete: 'Eliminar menú',
-      deleteMsg: 'Estás seguro de que deseas eliminar este menú?',
+      deleteMsg: '¿Estás seguro de que deseas eliminar este menú?',
       create: 'Crear Menú',
       menuName: 'Nombre menú',
       portions: 'Porciones',
@@ -113,6 +113,7 @@ export default {
       recipesQuantity: 'Cantidad de recetas',
       recipes: 'Recetas',
       noRecipes: 'Este menú aún no tiene recetas',
+      noNameAlert: 'Ingresa el nombre del menú por favor'
     },
     providers: {
       title: 'Proveedores',


### PR DESCRIPTION
# Contexto 

Habían 3 errores al crear un menú:

1. Al crear un menú, en el `index `no aparecía el valor del menú, sino que siempre 20.000 (hardcodeado)
2. Se podían crear menús sin nombres.
3. Cuando se crea una menú, hay un buscador de recetas que no filtraba ni funcionaba.

# QA

- Entrar a menús. Si hay menús creados, ahora se deben ver correctamente los valores de estos.
- Agregar una receta. Primero intentar sin agregar nombre (da lo mismo si hay o no recetas). No debe poder crearse la receta.
- Filtrar recetas por nombre con el buscador.
- Agregar alguna recetas con costo asociado.+
- Antes de agregar una receta, fijarse en el precio final.
- Crear la receta y ver que coincida el valor que se daba en `create` con el del `index`.

# Extra

En las líneas 85 y 86 del código habían un `editIngredient` y un `deleteIngredient`. Los cambie a  `editMenu` y `deleteMenu`, no tiene nada que ver con funcionalidad.