### PR TITLE
Fix/add scrollbars

### DIFF
--- a/app/javascript/components/menus/new/new-menu-container.vue
+++ b/app/javascript/components/menus/new/new-menu-container.vue
@@ -21,7 +21,7 @@
       <!-- Recipes -->
       <div class="flex justify-between mb-8">
         <div class="w-1/2 p-4">
-          <div class="flex flex-col">
+          <div class="flex flex-col w-auto">
             <!-- search bar -->
             <div class="relative text-yellow-700 my-4">
               <span class="absolute inset-y-0 left-0 flex items-center pl-3">
@@ -32,13 +32,13 @@
                 >
               </span>
               <input
-                class="flex py-2 px-12 w-96 h-16 bg-gray-50 border-2 border-gray-600 rounded self-stretch flex-grow-0 focus:outline-none"
+                class="flex py-2 px-12 w-full h-16 bg-gray-50 border-2 border-gray-600 rounded self-stretch flex-grow-0 focus:outline-none"
                 :placeholder="$t('msg.recipes.search')"
                 autocomplete="off"
               >
             </div>
             <!-- available recipes -->
-            <div class="flex flex-col bg-gray-200 overflow-scroll">
+            <div class="flex flex-col h-96 bg-gray-200 overflow-scroll">
               <add-recipe-card
                 v-for="recipe in recipes"
                 :key="recipe.id"
@@ -60,7 +60,7 @@
               {{ $t('msg.menus.selectedRecipes') }}
             </div>
             <div
-              class="flex flex-col bg-gray-200 overflow-scroll"
+              class="flex flex-col h-96 bg-gray-200 overflow-scroll"
               v-if="selectedRecipes.length > 0"
             >
               <div

--- a/app/javascript/components/recipes/base/recipe-ingredients.vue
+++ b/app/javascript/components/recipes/base/recipe-ingredients.vue
@@ -11,7 +11,8 @@
           v-model="query"
         >
         <!-- ingredientes disponibles -->
-        <div class="flex flex-col bg-gray-200 overflow-scroll">
+        <div class="flex flex-col items-start w-auto h-96 flex-none flex-grow-0 bg-gray-200 overflow-scroll">
+        <!-- <div class="flex flex-col bg-gray-200 overflow-scroll"> -->
           <add-ingredient-card
             v-for="ingredient in filteredIngredients"
             :key="ingredient.id"
@@ -31,7 +32,7 @@
           {{ $t('msg.recipes.selectedIngredients') }}
         </div>
         <div
-          class="flex flex-col bg-gray-200 overflow-scroll"
+          class="flex flex-col h-96 bg-gray-200 overflow-scroll"
           v-if="recipeIngredients.length > 0"
         >
           <div

--- a/app/javascript/components/recipes/base/recipe-ingredients.vue
+++ b/app/javascript/components/recipes/base/recipe-ingredients.vue
@@ -12,7 +12,6 @@
         >
         <!-- ingredientes disponibles -->
         <div class="flex flex-col items-start w-auto h-96 flex-none flex-grow-0 bg-gray-200 overflow-scroll">
-        <!-- <div class="flex flex-col bg-gray-200 overflow-scroll"> -->
           <add-ingredient-card
             v-for="ingredient in filteredIngredients"
             :key="ingredient.id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,11 +24,9 @@ ActiveRecord::Schema.define(version: 2021_06_04_152534) do
     t.bigint "author_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["author_type", "author_id"],
-            name: "index_active_admin_comments_on_author_type_and_author_id"
+    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
     t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
-    t.index ["resource_type", "resource_id"],
-            name: "index_active_admin_comments_on_resource_type_and_resource_id"
+    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"
   end
 
   create_table "admin_users", force: :cascade do |t|
@@ -40,8 +38,7 @@ ActiveRecord::Schema.define(version: 2021_06_04_152534) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token",
-                                      unique: true
+    t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 
   create_table "ingredients", force: :cascade do |t|


### PR DESCRIPTION
### Contexto
Al hacer unos cambios en la conexión con el bakend se perdierón los scrollbars que habían en el caso de recetas: para mostrar todos los ingredientes disponibles y aquellos seleccionados, y en el caso de menus: para mostrar todas las recetas disponibles y todas aquellas seleccionadas. Por lo tanto se mostraban las listas gigantes hacia abajo y ahora denuevo estan con scrollbars

### Qué hice
- le agregue una altura fija (w-96) y overflow-scroll a los div que iban a contener todas las tarjetas correspondientes.
- arregle unos detalles en el estilo de algunas componentes para que el buscador siguiera la misma linea de los elementos de su alrededor