### PR TITLE
fix(delete-ingredient-and-menu): fix bug in delete ingredient and menu

### DIFF
--- a/app/javascript/components/ingredients/ingredients-table.vue
+++ b/app/javascript/components/ingredients/ingredients-table.vue
@@ -63,7 +63,7 @@
               del:true
             }"
             @edit="editIngredient(ingredient)"
-            @del="deleteIngredient(ingredient)"
+            @delete="deleteIngredient(ingredient)"
           />
         </td>
       </tr>

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -83,7 +83,7 @@
               del:true
             }"
             @edit="editMenu(menu)"
-            @del="deleteMenu(menu)"
+            @delete="deleteMenu(menu)"
           />
         </td>
       </tr>


### PR DESCRIPTION
### Lo que se hizo

Se arreglaron unos errores que habían al eliminar ingredientes y eliminar menús. Era un error muy chico, tuve que cambiar la el nombre del evento que se recibe de del a delete.

### QA
Ir a la rama, crear ingredientes y probar eliminarlos. Lo mismo con los menus.