### PR TITLE
Fix(menu-disable-button):  disable button in add and edit recipe/menu when ingredient/recipe is already selected

### DIFF
--- a/app/javascript/components/menus/base/add-recipe-card.vue
+++ b/app/javascript/components/menus/base/add-recipe-card.vue
@@ -26,6 +26,8 @@
     <!-- button -->
     <button
       class="flex items-center py-1.5 px-4 w-auto h-9 bg-yellow-500 shadow-sm rounded-md flex-none my-auto mx-3"
+      :disabled="selected"
+      :class="selected ? 'opacity-25' : 'opacity-100'"
       @click="addRecipe()"
     >
       <div class="w-auto h-6 font-hind font-normal text-base text-white flex-none">
@@ -42,6 +44,8 @@ export default {
     name: { type: String, required: true },
     portions: { type: Number, required: true },
     minutes: { type: Number, required: true },
+    id: { type: String, required: true },
+    selectedRecipes: { type: Array, required: true },
     recipeIngredients: { type: Array, required: true },
   },
   methods: {
@@ -59,6 +63,14 @@ export default {
     recipePrice() {
       return this.recipeIngredients.reduce((recipePrice, recipeIngredient) =>
         recipePrice + this.getPriceOfSelectedIngredient(recipeIngredient.attributes), 0);
+    },
+    selected() {
+      const selectedRecipesIds = this.selectedRecipes.map(element => (
+        parseInt(element.id, 10)
+      ));
+      const isSelected = selectedRecipesIds.includes(parseInt(this.id, 10));
+
+      return isSelected;
     },
   },
 };

--- a/app/javascript/components/menus/edit/edit-menu-container.vue
+++ b/app/javascript/components/menus/edit/edit-menu-container.vue
@@ -39,7 +39,7 @@
                 >
               </span>
               <input
-                class="flex py-2 w-96 h-16 bg-gray-50 border-2 border-gray-600 rounded focus:outline-none"
+                class="flex py-2 px-12 w-96 h-16 bg-gray-50 border-2 border-gray-600 rounded focus:outline-none"
                 :placeholder="$t('msg.recipes.search')"
                 autocomplete="off"
               >

--- a/app/javascript/components/menus/edit/edit-menu-container.vue
+++ b/app/javascript/components/menus/edit/edit-menu-container.vue
@@ -52,6 +52,8 @@
                 :name="recipe.name"
                 :portions="recipe.portions"
                 :minutes="recipe.cookMinutes"
+                :selected-recipes="selectedRecipes"
+                :id="recipe.id"
                 :recipe-ingredients="recipe.recipeIngredients.data"
                 @add="addRecipe(recipe)"
               >

--- a/app/javascript/components/menus/new/new-menu-container.vue
+++ b/app/javascript/components/menus/new/new-menu-container.vue
@@ -44,6 +44,8 @@
               <add-recipe-card
                 v-for="recipe in filterRecipes"
                 :key="recipe.id"
+                :selected-recipes="selectedRecipes"
+                :id="recipe.id"
                 :name="recipe.name"
                 :portions="recipe.portions"
                 :minutes="recipe.cookMinutes"

--- a/app/javascript/components/recipes/base/add-ingredient-card.vue
+++ b/app/javascript/components/recipes/base/add-ingredient-card.vue
@@ -17,6 +17,8 @@
     <!-- button -->
     <button
       class="flex items-center py-1.5 px-4 w-auto h-9 bg-yellow-500 shadow-sm rounded-md flex-none flex-grow-0 my-auto mx-3"
+      :disabled="selected"
+      :class="selected ? 'opacity-25' : 'opacity-100'"
       @click="addIngredient()"
     >
       <div class="w-auto h-6 font-hind font-normal text-base text-white flex-none flex-grow-0">
@@ -31,11 +33,23 @@
 export default {
   props: {
     name: { type: String, required: true },
+    id: { type: String, required: true },
     price: { type: Number, required: true },
+    recipeIngredients: { type: Array, required: true },
   },
   methods: {
     addIngredient() {
       this.$emit('add');
+    },
+  },
+  computed: {
+    selected() {
+      const recipeIngredientsIds = this.recipeIngredients.map(element => (
+        parseInt(element.attributes.ingredient.id, 10)
+      ));
+      const isSelected = recipeIngredientsIds.includes(parseInt(this.id, 10));
+
+      return isSelected;
     },
   },
 };

--- a/app/javascript/components/recipes/base/recipe-ingredients.vue
+++ b/app/javascript/components/recipes/base/recipe-ingredients.vue
@@ -15,6 +15,8 @@
           <add-ingredient-card
             v-for="ingredient in filteredIngredients"
             :key="ingredient.id"
+            :recipe-ingredients="recipeIngredients"
+            :id="ingredient.id"
             :name="ingredient.name"
             :price="ingredient.price / ingredient.quantity"
             @add="addIngredient(ingredient)"


### PR DESCRIPTION
Base #88

# Lo que hice
- Deshabilitar los botones de agregar en vistas de editar y agregar receta/menú cuando un ingrediente/receta ya estaba seleccionado

# QA
- Ir a Recetas --> Agregar recetas --> Agregar un ingrediente. El botón Agregar de ese ingrediente debería verse más transparente y si se clickea no se agrega el ingrediente de nuevo a selecionados. Idem para Menú
- Ir a Recetas --> Editar alguna receta. Los ingredientes que ya pertenecen a la receta parten con el botón agregar más transparente y si se clickea no se agrega el ingrediente de nuevo. Ideam para menú

![image](https://user-images.githubusercontent.com/26123660/121602482-5a1e6f00-ca15-11eb-9fd7-98505db4f3e0.png)
