### PR TITLE
feat(api): change ingredient_qty to float and add measure

### DIFF
--- a/app/models/recipe_ingredient.rb
+++ b/app/models/recipe_ingredient.rb
@@ -10,9 +10,10 @@ end
 #  id                  :bigint(8)        not null, primary key
 #  recipe_id           :bigint(8)        not null
 #  ingredient_id       :bigint(8)        not null
-#  ingredient_quantity :integer
+#  ingredient_quantity :float
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  recipe_measure      :string
 #
 # Indexes
 #

--- a/db/migrate/20210610214559_change_ingredients_quantity_to_float.rb
+++ b/db/migrate/20210610214559_change_ingredients_quantity_to_float.rb
@@ -1,0 +1,7 @@
+class ChangeIngredientsQuantityToFloat < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured do
+      change_column :recipe_ingredients, :ingredient_quantity, :float
+    end
+  end
+end

--- a/db/migrate/20210610215639_add_ingredient_measure_to_recipe_ingredients.rb
+++ b/db/migrate/20210610215639_add_ingredient_measure_to_recipe_ingredients.rb
@@ -1,0 +1,5 @@
+class AddIngredientMeasureToRecipeIngredients < ActiveRecord::Migration[6.0]
+  def change
+    add_column :recipe_ingredients, :recipe_measure, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -96,9 +96,10 @@ ActiveRecord::Schema.define(version: 2021_06_10_220621) do
   create_table "recipe_ingredients", force: :cascade do |t|
     t.bigint "recipe_id", null: false
     t.bigint "ingredient_id", null: false
-    t.integer "ingredient_quantity"
+    t.float "ingredient_quantity"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "recipe_measure"
     t.index ["ingredient_id"], name: "index_recipe_ingredients_on_ingredient_id"
     t.index ["recipe_id"], name: "index_recipe_ingredients_on_recipe_id"
   end


### PR DESCRIPTION
Cambio la columna de `ingredients_quantity` a float para poder usar una fracción de cierta measure, y agrego la columna `ingredient_measure` a la relación con receta para saber qué medida estamos usando al agregar un ingrediente a la receta