### PR TITLE
Units edit recipe

### DIFF
--- a/app/javascript/components/recipes/base/add-ingredient-card.vue
+++ b/app/javascript/components/recipes/base/add-ingredient-card.vue
@@ -2,8 +2,11 @@
   <div class="flex items-start justify-between w-full h-20 border border-gray-500 bg-gray-50 flex-none flex-grow-0">
     <!-- data -->
     <div class="flex flex-col items-start w-auto h-14 flex-none flex-grow-0 mx-3 my-auto">
-      <div class="w-auto h-7 font-hind font-bold text-lg text-black flex-none flex-grow-0 mb-0.5">
+      <div class="w-auto h-7 font-hind font-bold text-lg text-black flex-none flex-grow-0">
         {{ name }}
+      </div>
+      <div class="w-auto h-4 font-hind font-normal text-sm text-black flex-none flex-grow-0">
+        {{ quantity }} {{ measure }}
       </div>
       <div class="flex items-center w-auto h-5 flex-none flex-grow-0">
         <div class="w-auto h-5 font-hind font-light text-sm text-gray-600 flex-none flex-grow-0 mr-0.5">
@@ -35,6 +38,8 @@ export default {
     name: { type: String, required: true },
     id: { type: String, required: true },
     price: { type: Number, required: true },
+    quantity: { type: Number, required: true },
+    measure: { type: String, required: true },
     recipeIngredients: { type: Array, required: true },
   },
   methods: {

--- a/app/javascript/components/recipes/base/recipe-ingredients.vue
+++ b/app/javascript/components/recipes/base/recipe-ingredients.vue
@@ -19,6 +19,8 @@
             :id="ingredient.id"
             :name="ingredient.name"
             :price="ingredient.price / ingredient.quantity"
+            :quantity="ingredient.quantity"
+            :measure="ingredient.measure"
             @add="addIngredient(ingredient)"
           >
             {{ ingredient.name }}

--- a/app/javascript/components/recipes/base/selected-ingredient-card.vue
+++ b/app/javascript/components/recipes/base/selected-ingredient-card.vue
@@ -10,7 +10,8 @@
           {{ $t('msg.recipes.price') }} {{ $t('msg.recipes.unitary') }}
         </div>
         <div class="h-5 font-hind font-normal text-sm text-black">
-          $ {{ recipeIngredientAttrs.ingredient.price }} CLP
+          $ {{ recipeIngredientAttrs.ingredient.price / recipeIngredientAttrs.ingredient.quantity }} CLP por
+          {{ recipeIngredientAttrs.ingredient.measure }}
         </div>
       </div>
       <div class="flex items-center h-4">

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -15,6 +15,7 @@ export default {
     min: 'Mínimo',
     max: 'Máximo',
     quantity: 'Cantidad',
+    space: ' ',
 
     users: {
       registerTitle: 'Crear Cuenta',

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -15,7 +15,6 @@ export default {
     min: 'Mínimo',
     max: 'Máximo',
     quantity: 'Cantidad',
-    space: ' ',
 
     users: {
       registerTitle: 'Crear Cuenta',


### PR DESCRIPTION
### Lo que se hizo
Se arregló un bug que se calculaba mal el precio unitario al editar receta.
Además, se agrego la unidad de medida para saber cuanto de cada ingrediente se esta agregando o quitando de la receta al editarla. (Esto fue solicitado por Platanus en la demo pasada)

### QA
Ir a una receta, editarla y ver que el precio por unidad se esté calculando correctamente y que sea el mismo en ambas columnas (de ingredientes y de ingredientes seleccionados).

![Captura de pantalla 2021-06-11 a la(s) 16 22 29](https://user-images.githubusercontent.com/48296628/121744988-bc3caa00-cad1-11eb-8ec7-f9adf6d0b22e.png)
