### PR TITLE
feat(menus): add shopping list to menu

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'activeadmin_addons'
 gem 'active_skin', github: 'SoftwareBrothers/active_skin'
 gem 'aws-sdk-s3', '~> 1.0'
 gem 'bootsnap', require: false
+gem 'caxlsx'
 gem 'data_migrate'
 gem 'devise'
 gem 'devise-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,11 @@ GEM
     byebug (11.1.3)
     case_transform (0.2)
       activesupport
+    caxlsx (3.0.4)
+      htmlentities (~> 4.3, >= 4.3.4)
+      mimemagic (~> 0.3)
+      nokogiri (~> 1.10, >= 1.10.4)
+      rubyzip (>= 1.3.0, < 3)
     childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
@@ -204,6 +209,7 @@ GEM
       activesupport (>= 5.2)
     heroku-stage (0.4.0)
       rails
+    htmlentities (4.3.4)
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -538,6 +544,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap
+  caxlsx
   data_migrate
   devise
   devise-i18n

--- a/app/assets/images/download-svg.svg
+++ b/app/assets/images/download-svg.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+</svg>

--- a/app/assets/images/shopping-bag-svg.svg
+++ b/app/assets/images/shopping-bag-svg.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
+</svg>

--- a/app/commands/generate_shopping_list_file.rb
+++ b/app/commands/generate_shopping_list_file.rb
@@ -1,0 +1,45 @@
+class GenerateShoppingListFile < PowerTypes::Command.new(:shopping_list_json)
+  def perform
+    add_header
+    add_body
+    axlsx.to_stream.string
+  end
+
+  private
+
+  def add_header
+    xls_sheet.add_row(
+      [
+        'Proveedor',
+        'Nombre',
+        'Medida',
+        'Cantidad',
+        'Precio total'
+      ]
+    )
+  end
+
+  def add_body
+    @shopping_list_json.each do |element|
+      element[:ingredients].each do |ingredient|
+        xls_sheet.add_row(
+          [
+            element[:provider],
+            ingredient[:name],
+            ingredient[:measure],
+            ingredient[:quantity],
+            ingredient[:total_price]
+          ]
+        )
+      end
+    end
+  end
+
+  def axlsx
+    @axlsx ||= ::Axlsx::Package.new
+  end
+
+  def xls_sheet
+    @xls_sheet ||= axlsx.workbook.add_worksheet
+  end
+end

--- a/app/javascript/api/menus.js
+++ b/app/javascript/api/menus.js
@@ -39,10 +39,8 @@ function getShoppingList(menuId) {
 }
 
 function downloadShoppingList(menuId) {
-  return (client
-    .get(`/menus/${menuId}/download-shopping-list`, {
-      responseType: 'blob',
-    }));
+  const url = `${client.defaults.baseURL}/menus/${menuId}/download-shopping-list`;
+  window.open(url, '_blank');
 }
 
 export { getMenus, getMenu, postMenu, updateMenu, deleteMenu,

--- a/app/javascript/api/menus.js
+++ b/app/javascript/api/menus.js
@@ -32,4 +32,10 @@ function deleteMenu(menuId) {
     }));
 }
 
-export { getMenus, getMenu, postMenu, updateMenu, deleteMenu };
+function getShoppingList(menuId) {
+  return (client
+    .get(`/menus/${menuId}/shopping-list`, {
+    }));
+}
+
+export { getMenus, getMenu, postMenu, updateMenu, deleteMenu, getShoppingList };

--- a/app/javascript/api/menus.js
+++ b/app/javascript/api/menus.js
@@ -38,4 +38,12 @@ function getShoppingList(menuId) {
     }));
 }
 
-export { getMenus, getMenu, postMenu, updateMenu, deleteMenu, getShoppingList };
+function downloadShoppingList(menuId) {
+  return (client
+    .get(`/menus/${menuId}/download-shopping-list`, {
+      responseType: 'blob',
+    }));
+}
+
+export { getMenus, getMenu, postMenu, updateMenu, deleteMenu,
+  getShoppingList, downloadShoppingList };

--- a/app/javascript/components/base/base-spinner.vue
+++ b/app/javascript/components/base/base-spinner.vue
@@ -1,9 +1,9 @@
 <template>
   <div
-    class="p-1 focus:outline-none focus:shadow-outline"
+    class="focus:outline-none focus:shadow-outline text-center"
   >
     <svg
-      class="animate-spin -ml-1 mr-3 w-5 h-5 text-black"
+      class="animate-spin w-full h-full text-black"
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"

--- a/app/javascript/components/ingredients/search-market-ingredients.vue
+++ b/app/javascript/components/ingredients/search-market-ingredients.vue
@@ -33,12 +33,16 @@
                 >
               </button>
             </span>
-            <span
+            <div
+              class="p-1"
               v-else
-              class="flex pl-3 my-auto"
             >
-              <base-spinner />
-            </span>
+              <span
+                class="flex my-auto w-8 h-8 pl-2"
+              >
+                <base-spinner />
+              </span>
+            </div>
           </div>
         </div>
       </div>

--- a/app/javascript/components/menus/index/menu-shopping-list.vue
+++ b/app/javascript/components/menus/index/menu-shopping-list.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="w-full m-auto">
+    <button
+      class="focus:outline-none"
+      @click="showList"
+    >
+      <img
+        svg-inline
+        src="../../../../assets/images/shopping-bag-svg.svg"
+        class="w-6 h-6 text-yellow-700"
+      >
+    </button>
+    <base-modal
+      @cancel="showList"
+      v-if="showingList"
+      :title="$t('msg.menus.shoppingList')"
+      :cancel-button-label="$t('msg.menus.closeShoppingList')"
+      :ok-button-present="false"
+    >
+      <div
+        v-if="!loading"
+      >
+        <div
+          v-for="(element, idx) in menuIngredients"
+          :key="idx"
+        >
+          <div class="flex flex-col pb-3">
+            <div class="text-md font-bold">
+              {{ element.provider }}
+            </div>
+            <div
+              class="flex text-sm"
+              v-for="(ingredient, ingredient_idx) in element.ingredients"
+              :key="ingredient_idx"
+            >
+              {{ formatIngredientInfo(ingredient) }}
+            </div>
+          </div>
+        </div>
+      </div>
+      <span
+        v-else
+        class="flex justify-center m-auto w-8 h-8"
+      >
+        <base-spinner />
+      </span>
+    </base-modal>
+  </div>
+</template>
+
+<script>
+
+import { getShoppingList } from '../../../api/menus';
+
+export default {
+  props: {
+    menuId: { type: String, required: true },
+  },
+  data() {
+    return {
+      showingList: false,
+      menuIngredients: [],
+      loading: true,
+    };
+  },
+  methods: {
+    async showList() {
+      this.showingList = !this.showingList;
+
+      if (this.menuIngredients.length > 0) return;
+
+      this.loading = true;
+      const menuIngredientsResponse = await getShoppingList(this.menuId);
+      this.menuIngredients = menuIngredientsResponse.data;
+      this.loading = false;
+    },
+    formatIngredientInfo(ingredient) {
+      return `${ingredient.name}, ${ingredient.quantity} ${ingredient.measure}, $ ${ingredient.totalPrice}`;
+    },
+  },
+};
+
+</script>

--- a/app/javascript/components/menus/index/menu-shopping-list.vue
+++ b/app/javascript/components/menus/index/menu-shopping-list.vue
@@ -98,18 +98,7 @@ export default {
       return `${ingredient.name}, ${ingredient.quantity} ${ingredient.measure}, $ ${ingredient.totalPrice}`;
     },
     async downloadShoppingList() {
-      const response = await downloadShoppingList(this.menuId);
-      const blob = new Blob(
-        [response.data], {
-          type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-        },
-      );
-      const link = document.createElement('a');
-      link.download = 'shopping-list.xlsx';
-      link.href = URL.createObjectURL(blob);
-      link.click();
-      URL.revokeObjectURL(link.href);
-      this.toggleList();
+      downloadShoppingList(this.menuId);
     },
   },
 };

--- a/app/javascript/components/menus/index/menu-shopping-list.vue
+++ b/app/javascript/components/menus/index/menu-shopping-list.vue
@@ -2,7 +2,7 @@
   <div class="w-full m-auto">
     <button
       class="focus:outline-none"
-      @click="showList"
+      @click="toogleList"
     >
       <img
         svg-inline
@@ -11,7 +11,7 @@
       >
     </button>
     <base-modal
-      @cancel="showList"
+      @cancel="toogleList"
       v-if="showingList"
       :title="$t('msg.menus.shoppingList')"
       :cancel-button-label="$t('msg.menus.closeShoppingList')"
@@ -20,22 +20,42 @@
       <div
         v-if="!loading"
       >
-        <div
-          v-for="(element, idx) in menuIngredients"
-          :key="idx"
-        >
-          <div class="flex flex-col pb-3">
-            <div class="text-md font-bold">
-              {{ element.provider }}
-            </div>
-            <div
-              class="flex text-sm"
-              v-for="(ingredient, ingredient_idx) in element.ingredients"
-              :key="ingredient_idx"
-            >
-              {{ formatIngredientInfo(ingredient) }}
+        <div class="pb-6">
+          <div
+            v-for="(element, idx) in menuIngredients"
+            :key="idx"
+          >
+            <div class="flex flex-col pb-3">
+              <div class="text-md font-bold">
+                {{ element.provider }}
+              </div>
+              <div
+                class="flex text-sm"
+                v-for="(ingredient, ingredient_idx) in element.ingredients"
+                :key="ingredient_idx"
+              >
+                {{ formatIngredientInfo(ingredient) }}
+              </div>
             </div>
           </div>
+        </div>
+
+        <div class="flex">
+          <button
+            class="focus:outline-none bg-gray-300 hover:bg-gray-400 p-4 mx-2 my-2 h-10 font-bold py-2 px-6 rounded shadow-md"
+            @click="downloadShoppingList"
+          >
+            <div class="flex">
+              <div class="text-md">
+                {{ $t('msg.download') }}
+              </div>
+              <img
+                svg-inline
+                src="../../../../assets/images/download-svg.svg"
+                class="w-6 h-6"
+              >
+            </div>
+          </button>
         </div>
       </div>
       <span
@@ -50,7 +70,7 @@
 
 <script>
 
-import { getShoppingList } from '../../../api/menus';
+import { getShoppingList, downloadShoppingList } from '../../../api/menus';
 
 export default {
   props: {
@@ -64,7 +84,7 @@ export default {
     };
   },
   methods: {
-    async showList() {
+    async toogleList() {
       this.showingList = !this.showingList;
 
       if (this.menuIngredients.length > 0) return;
@@ -76,6 +96,20 @@ export default {
     },
     formatIngredientInfo(ingredient) {
       return `${ingredient.name}, ${ingredient.quantity} ${ingredient.measure}, $ ${ingredient.totalPrice}`;
+    },
+    async downloadShoppingList() {
+      const response = await downloadShoppingList(this.menuId);
+      const blob = new Blob(
+        [response.data], {
+          type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        },
+      );
+      const link = document.createElement('a');
+      link.download = 'shopping-list.xlsx';
+      link.href = URL.createObjectURL(blob);
+      link.click();
+      URL.revokeObjectURL(link.href);
+      this.toogleList();
     },
   },
 };

--- a/app/javascript/components/menus/index/menu-shopping-list.vue
+++ b/app/javascript/components/menus/index/menu-shopping-list.vue
@@ -2,7 +2,7 @@
   <div class="w-full m-auto">
     <button
       class="focus:outline-none"
-      @click="toogleList"
+      @click="toggleList"
     >
       <img
         svg-inline
@@ -11,7 +11,7 @@
       >
     </button>
     <base-modal
-      @cancel="toogleList"
+      @cancel="toggleList"
       v-if="showingList"
       :title="$t('msg.menus.shoppingList')"
       :cancel-button-label="$t('msg.menus.closeShoppingList')"
@@ -84,7 +84,7 @@ export default {
     };
   },
   methods: {
-    async toogleList() {
+    async toggleList() {
       this.showingList = !this.showingList;
 
       if (this.menuIngredients.length > 0) return;
@@ -109,7 +109,7 @@ export default {
       link.href = URL.createObjectURL(blob);
       link.click();
       URL.revokeObjectURL(link.href);
-      this.toogleList();
+      this.toggleList();
     },
   },
 };

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -1,5 +1,5 @@
 <template>
-  <table class="min-w-full divide-y divide-gray-200">
+  <table class="w-full divide-y divide-gray-200">
     <thead class="justify-between bg-gray-600 border-4 border-gray-600">
       <tr class="text-left">
         <th
@@ -22,6 +22,9 @@
         >
           <span class="text-white font-bold">{{ $t('msg.menus.recipes') }}</span>
         </th>
+        <th
+          class="px-8 py-3"
+        />
         <th
           class="px-8 py-3"
         />
@@ -73,7 +76,13 @@
             :menu="menu"
           />
         </td>
-        <!-- dots -->
+        <td
+          class="content-center"
+        >
+          <menu-shopping-list
+            :menu-id="menu.id"
+          />
+        </td>
         <td
           class="content-center"
         >
@@ -94,11 +103,13 @@
 <script>
 import MenusTableRecipesQuantity from './menus-table-recipes-quantity';
 import MenusTableRecipes from './menus-table-recipes';
+import MenuShoppingList from './menu-shopping-list';
 
 export default {
   components: {
     MenusTableRecipesQuantity,
     MenusTableRecipes,
+    MenuShoppingList,
   },
   props: {
     menus: { type: Array, required: true },

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -120,6 +120,8 @@ export default {
       noRecipes: 'Este menú aún no tiene recetas',
       noNameAlert: 'Ingresa el nombre del menú por favor',
       saveChanges: 'Guardar cambios',
+      shoppingList: 'Lista de compras',
+      closeShoppingList: 'Cerrar',
     },
     providers: {
       title: 'Proveedores',

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -15,6 +15,7 @@ export default {
     min: 'Mínimo',
     max: 'Máximo',
     quantity: 'Cantidad',
+    download: 'Descargar',
 
     users: {
       registerTitle: 'Crear Cuenta',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
         member do
           post '/reduce-inventory', to: 'menus#reduce_inventory'
           get '/shopping-list', to: 'menus#shopping_list'
+          get '/download-shopping-list', to: 'menus#download_shopping_list'
         end
       end
       resources :recipes do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
         resources :menu_recipes, only: [:create, :update, :destroy]
         member do
           post '/reduce-inventory', to: 'menus#reduce_inventory'
+          get '/shopping-list', to: 'menus#shopping_list'
         end
       end
       resources :recipes do


### PR DESCRIPTION

Card https://trello.com/c/NbH10C37/9-generar-lista-de-compras

#### Contexto
Actualmente el menú tiene recetas (puede tener 5 recetas de pastel de choclo) y cada receta tiene muchos ingredientes (5 choclos cada receta). Cada ingrediente tiene una medida por default (la primera de todas las que tiene)

#### Qué hice
- Modifiqué el spinner para que sea tamaño por default, ahora el loading se puede usar en cualquier parte más bonito y el wrapper se hace afuera
- Creo el backend y frontend web para ver la lista de compras de un menú.

Ahora el spinner el buscar en ingredientes:

https://user-images.githubusercontent.com/30879716/121785231-8d344000-cb86-11eb-9af3-8fda6c08517b.mov

La lista de compras de cada menú (no se ve el spinner porque está muy rápido :hyper-fast-parrot:):


https://user-images.githubusercontent.com/30879716/121785253-c2409280-cb86-11eb-8d79-dd6a48a5db86.mov

### Qué falta

- [x] Botón para descargar planilla con estos datos (PR #105)