### PR TITLE
feat(api): add id to ingredient serializer

### DIFF
--- a/app/serializers/api/v1/ingredient_serializer.rb
+++ b/app/serializers/api/v1/ingredient_serializer.rb
@@ -2,6 +2,7 @@ class Api::V1::IngredientSerializer < ActiveModel::Serializer
   type :ingredient
 
   attributes(
+    :id,
     :provider_id,
     :user_id,
     :name,


### PR DESCRIPTION
Agrego el id al serializer del ingrediente, para que así se puedan usar otras funciones al obtener las recetas