### PR TITLE
feat(ingredient): add primary measure

### DIFF
--- a/app/controllers/api/v1/ingredients_controller.rb
+++ b/app/controllers/api/v1/ingredients_controller.rb
@@ -73,7 +73,7 @@ class Api::V1::IngredientsController < Api::V1::BaseController
       :currency,
       :inventory,
       :provider_name,
-      ingredient_measures_attributes: [:id, :name, :quantity, :_destroy]
+      ingredient_measures_attributes: [:id, :name, :quantity, :primary, :_destroy]
     )
   end
 end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -21,7 +21,18 @@ class Ingredient < ApplicationRecord
     default_measure&.quantity
   end
 
+  def factor_of_default_quantity_by_measure(measure_name)
+    default_quantity = default_measure&.quantity
+    return if default_quantity.blank?
+
+    default_quantity / ingredient_measures.find_by(name: measure_name).quantity
+  end
+
   def default_measure
+    default = ingredient_measures.find_by(primary: true)
+
+    return default if default.present?
+
     ingredient_measures.first
   end
 end

--- a/app/models/ingredient_measure.rb
+++ b/app/models/ingredient_measure.rb
@@ -12,10 +12,12 @@ end
 #  name          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  primary       :boolean          default(FALSE)
 #
 # Indexes
 #
-#  index_ingredient_measures_on_ingredient_id  (ingredient_id)
+#  index_ingredient_measures_on_ingredient_id           (ingredient_id)
+#  index_ingredient_measures_on_name_and_ingredient_id  (name,ingredient_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/db/migrate/20210620030919_add_primary_to_ingredient_measure.rb
+++ b/db/migrate/20210620030919_add_primary_to_ingredient_measure.rb
@@ -1,0 +1,5 @@
+class AddPrimaryToIngredientMeasure < ActiveRecord::Migration[6.0]
+  def change
+    add_column :ingredient_measures, :primary, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_13_002438) do
-
+ActiveRecord::Schema.define(version: 2021_06_20_030919) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,9 +23,11 @@ ActiveRecord::Schema.define(version: 2021_06_13_002438) do
     t.bigint "author_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
+    t.index ["author_type", "author_id"],
+            name: "index_active_admin_comments_on_author_type_and_author_id"
     t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
-    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"
+    t.index ["resource_type", "resource_id"],
+            name: "index_active_admin_comments_on_resource_type_and_resource_id"
   end
 
   create_table "admin_users", force: :cascade do |t|
@@ -38,7 +39,8 @@ ActiveRecord::Schema.define(version: 2021_06_13_002438) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
+    t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token",
+                                      unique: true
   end
 
   create_table "ingredient_measures", force: :cascade do |t|
@@ -47,7 +49,10 @@ ActiveRecord::Schema.define(version: 2021_06_13_002438) do
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "primary", default: false
     t.index ["ingredient_id"], name: "index_ingredient_measures_on_ingredient_id"
+    t.index ["name", "ingredient_id"], name: "index_ingredient_measures_on_name_and_ingredient_id",
+                                       unique: true
   end
 
   create_table "ingredients", force: :cascade do |t|

--- a/spec/integration/api/v1/ingredients_spec.rb
+++ b/spec/integration/api/v1/ingredients_spec.rb
@@ -321,7 +321,7 @@ describe 'API::V1::Ingredients', swagger_doc: 'v1/swagger.json' do
             currency: 'Some currency',
             inventory: 15,
             ingredient_measures_attributes: [
-              { name: 'Kg', quantity: 5 },
+              { name: 'Kg', quantity: 5, primary: true },
               { name: 'Tazas', quantity: 25 }
             ]
           }

--- a/spec/swagger/v1/schemas/ingredient_measure_schema.rb
+++ b/spec/swagger/v1/schemas/ingredient_measure_schema.rb
@@ -4,6 +4,7 @@ INGREDIENT_MEASURE_SCHEMA = {
   type: :object,
   properties: {
     name: { type: :string, example: 'unidad' },
-    quantity: { type: :integer, example: 2 }
+    quantity: { type: :integer, example: 2 },
+    primary: { type: :boolean, example: true }
   }
 }

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -1116,6 +1116,10 @@
         "quantity": {
           "type": "integer",
           "example": 2
+        },
+        "primary": {
+          "type": "boolean",
+          "example": true
         }
       }
     }
@@ -1405,7 +1409,7 @@
         ],
         "responses": {
           "200": {
-            "description": "ingredient updated"
+            "description": "ingredient updated with measure by default"
           },
           "401": {
             "description": "user unauthorized"
@@ -1747,6 +1751,41 @@
         "responses": {
           "200": {
             "description": "reduced inventory of menu"
+          }
+        }
+      }
+    },
+    "/menus/{id}/shopping-list": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "type": "integer",
+          "required": true
+        },
+        {
+          "name": "user_email",
+          "in": "query",
+          "type": "string"
+        },
+        {
+          "name": "user_token",
+          "in": "query",
+          "type": "string"
+        }
+      ],
+      "get": {
+        "summary": "Returns Menu Ingredients, same as shopping list",
+        "description": "Get ingredients of a menu with quantities, prices, measures grouped by provider",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "shopping list grouped by provider"
           }
         }
       }


### PR DESCRIPTION
Antes usábamos como measure default la primera de las measures. Ahora creo el atributo `primary`, el cual usaremos para esta measure default.

Teniendo esto, la idea es que esta measure default sea la usada para el inventario, es decir, cuando diga "tengo 3 de Plátanos", si el default es Kg, entonces tiene 3 Kg de plátanos.

Así entonces reconstruí el reducir menú, que toma todos los ingredientes usados en un menú a través de recetas y disminuyo el inventario. Ahora, dentro de una receta de un menú se pueden usar Unidades de platanos, por lo que se hizo la transformación de cantidades.

También agrego un endpoint a swagger que estaba perdido de antes: shopping list.

### QA

Crear un menú con distintas recetas e ingredientes (con inventario, aumentarlo por consola). Usar el endpoint `menus/{id}/reduce-inventory` y comprobar que los nuevos inventarios estén bien