### PR TITLE
feat(filter): can delete filter in the same view

### DIFF
--- a/app/javascript/components/recipes/index/filters.vue
+++ b/app/javascript/components/recipes/index/filters.vue
@@ -16,12 +16,36 @@
     </button>
     <!-- Filters -->
     <div
-      v-for="filter in filterOptions"
-      :key="filter"
-      class="flex flex-row inline-block items-center justify-center px-3 py-3 static w-auto h-8
-      rounded-full flex-none flex-grow-0 mx-2.5 bg-yellow-500 text-white"
+      v-if="filters.price.min !== '' || filters.price.max !== ''"
     >
-      {{ filters[filter].min }} &lt; {{ $t(`msg.recipes.${filter}`) }} &lt; {{ filters[filter].max }}
+      <div
+        class="flex flex-row inline-block items-center justify-center px-3 py-3 static w-auto h-8
+      rounded-full flex-none flex-grow-0 mx-3.5 bg-yellow-500 text-white"
+      >
+        {{ filters.price.min }} &lt; {{ $t(`msg.recipes.price`) }} &lt; {{ filters.price.max }}
+        <img
+          svg-inline
+          src="../../../../assets/images/cross-svg.svg"
+          class="h-4 w-4 inline-block ml-3"
+          @click="toggleDeletePrice"
+        >
+      </div>
+    </div>
+    <div
+      v-if="filters.portions.min !== '' || filters.portions.max !== ''"
+    >
+      <div
+        class="flex flex-row inline-block items-center justify-center px-3 py-3 static w-auto h-8
+      rounded-full flex-none flex-grow-0 mx-3.5 bg-yellow-500 text-white"
+      >
+        {{ filters.portions.min }} &lt; {{ $t(`msg.recipes.filter.portions`) }} &lt; {{ filters.portions.max }}
+        <img
+          svg-inline
+          src="../../../../assets/images/cross-svg.svg"
+          class="h-4 w-4 inline-block ml-3"
+          @click="toggleDeletePortions"
+        >
+      </div>
     </div>
   </div>
 </template>
@@ -36,6 +60,12 @@ export default {
   methods: {
     filtersButtonClick() {
       this.$emit('filters');
+    },
+    toggleDeletePrice() {
+      this.$emit('deletePrice');
+    },
+    toggleDeletePortions() {
+      this.$emit('deletePortions');
     },
   },
   data() {

--- a/app/javascript/components/recipes/index/filters.vue
+++ b/app/javascript/components/recipes/index/filters.vue
@@ -16,7 +16,7 @@
     </button>
     <!-- Filters -->
     <div
-      v-if="filters.price.min !== '' || filters.price.max !== ''"
+      v-if="filters.price.min || filters.price.max"
     >
       <div
         class="flex flex-row inline-block items-center justify-center px-3 py-3 static w-auto h-8
@@ -32,7 +32,7 @@
       </div>
     </div>
     <div
-      v-if="filters.portions.min !== '' || filters.portions.max !== ''"
+      v-if="filters.portions.min || filters.portions.max"
     >
       <div
         class="flex flex-row inline-block items-center justify-center px-3 py-3 static w-auto h-8

--- a/app/javascript/components/recipes/index/recipes-container.vue
+++ b/app/javascript/components/recipes/index/recipes-container.vue
@@ -37,6 +37,8 @@
         :filters="filters"
         :filter-options="filterOptions"
         @filters="toggleFiltersModal"
+        @deletePrice="toggleDeletePriceByCross"
+        @deletePortions="toggleDeletePortionsByCross"
       />
       <!-- Content -->
       <p
@@ -180,6 +182,14 @@ export default {
       this.filters.price.min = '';
       this.filters.price.max = '';
       this.showingFiltersModal = !this.showingFiltersModal;
+    },
+    toggleDeletePriceByCross() {
+      this.filters.price.min = '';
+      this.filters.price.max = '';
+    },
+    toggleDeletePortionsByCross() {
+      this.filters.portions.min = '';
+      this.filters.portions.max = '';
     },
     updateFilters() {
       this.showingFiltersModal = !this.showingFiltersModal;

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -85,7 +85,7 @@ export default {
       saveChanges: 'Guardar cambios',
       filter: {
         price: 'Precio',
-        portions: 'Porciones',
+        portions: 'Nº de Porciones',
         minPortions: 'Mínimas',
         maxPortions: 'Máximas',
         minPrice: 'Mínimo',


### PR DESCRIPTION
### Lo que se hizo
Se permitió poder borrar el filtro desde la misma vista con una "X" y que no sea necesario abrir el form de los filtros.
Además no se muestran en la vista los filtros (EJ: < precio < ) en caso de no existir ya que la comparación es con algo que no existe. Ahora se muestran los filtros (EJ: 2 < Nº porciones < 5) solo cuando existe el filtro de porciones.

### QA
Ir a /recipes, crear un par de recetas. Se debería ver algo así.
![Captura de pantalla 2021-06-22 a la(s) 12 27 27](https://user-images.githubusercontent.com/48296628/122964473-4ea43f80-d355-11eb-9488-63653d6e7747.png)

Después crear algunos filtros y se debería ver algo así:
![Captura de pantalla 2021-06-22 a la(s) 12 27 40](https://user-images.githubusercontent.com/48296628/122964550-624fa600-d355-11eb-84ef-5a07c7081ead.png)

Finalmente usar la X al lado del filtro para eliminarlo.
