### PR TITLE
open modal to add market ingredient

### DIFF
--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -72,6 +72,7 @@
           ref="addIngredientInfo"
           :units="['Kg','Litro', 'Cucharadas', 'Unidades', 'Oz']"
           :edit-mode="false"
+          :market-ingredient="marketIngredient"
         />
       </base-modal>
 
@@ -139,6 +140,7 @@ export default {
       ingredientToEdit: {},
       ingredientToDelete: {},
       ingredients: [],
+      marketIngredient: undefined,
       searchQuery: '',
       error: '',
     };
@@ -179,6 +181,7 @@ export default {
   methods: {
     toggleAddModal() {
       this.showingAdd = !this.showingAdd;
+      this.marketIngredient = undefined;
     },
 
     toggleSearchIngredientsModal() {
@@ -218,20 +221,8 @@ export default {
 
     async addMarketIngredient(productForm) {
       this.toggleSearchIngredientsModal();
-
-      try {
-        const {
-          data:
-            {
-              data: { id, attributes },
-            },
-        } = await postIngredient(productForm);
-        const ingredientToAdd = { id, ...attributes };
-        this.ingredients.push(ingredientToAdd);
-        this.error = '';
-      } catch (error) {
-        this.error = error;
-      }
+      this.toggleAddModal();
+      this.marketIngredient = productForm;
     },
 
     async editIngredient() {

--- a/app/javascript/components/ingredients/ingredients-form.vue
+++ b/app/javascript/components/ingredients/ingredients-form.vue
@@ -36,6 +36,15 @@
             v-model="form.provider_name"
             id="ingredient-provider"
           >
+            <!--Add Mode unit from market -->
+            <option
+              v-if="!editMode && marketIngredient !== undefined"
+              selected
+              :key="form.provider_name"
+              :value="form.provider_name"
+            >
+              {{ form.provider_name }}
+            </option>
             <option
               v-for="(name, idx) in providersNames"
               :key="idx"
@@ -92,13 +101,15 @@
                 rounded leading-tight focus:outline-none"
                 v-model="unit.name"
               >
-                <!--Add Mode unit Unselected -->
+                <!--Add Mode unit from market -->
                 <option
-                  v-if="!editMode"
+                  v-if="!editMode && marketIngredient !== undefined"
                   hidden
                   selected
+                  :key="form.ingredient_measures_attributes[0].name"
+                  :value="form.ingredient_measures_attributes[0].name"
                 >
-                  {{ $t('msg.ingredients.measure') }}
+                  {{ form.ingredient_measures_attributes[0].name }}
                 </option>
                 <!--Edit Mode unit ingredient -->
                 <option
@@ -180,6 +191,7 @@ export default {
       return {};
     } },
     units: { type: Array, required: true },
+    marketIngredient: { type: Object, default: undefined },
   },
 
   data() {
@@ -214,32 +226,36 @@ export default {
     },
   },
   async created() {
-    const {
-      providerName,
-      name,
-      sku,
-      price,
-      currency,
-      otherMeasures,
-    } = this.ingredient;
-    let ingredient_measures_attributes; /* eslint-disable-line camelcase */
-    if (otherMeasures) {
-      ingredient_measures_attributes = otherMeasures.data.map(unit => /* eslint-disable-line camelcase */
-        Object.assign({}, { id: unit.id }, unit.attributes),
-      );
+    if (this.marketIngredient === undefined) {
+      const {
+        providerName,
+        name,
+        sku,
+        price,
+        currency,
+        otherMeasures,
+      } = this.ingredient;
+      let ingredient_measures_attributes; /* eslint-disable-line camelcase */
+      if (otherMeasures) {
+        ingredient_measures_attributes = otherMeasures.data.map(unit => /* eslint-disable-line camelcase */
+          Object.assign({}, { id: unit.id }, unit.attributes),
+        );
+      } else {
+        ingredient_measures_attributes = [{ /* eslint-disable-line camelcase */
+          name: undefined, quantity: undefined, id: undefined,
+        }];
+      }
+      this.form = {
+        provider_name: providerName, /* eslint-disable-line camelcase */
+        name,
+        sku,
+        price,
+        currency,
+        ingredient_measures_attributes, /* eslint-disable-line camelcase */
+      };
     } else {
-      ingredient_measures_attributes = [{ /* eslint-disable-line camelcase */
-        name: undefined, quantity: undefined, id: undefined,
-      }];
+      this.form = this.marketIngredient;
     }
-    this.form = {
-      provider_name: providerName, /* eslint-disable-line camelcase */
-      name,
-      sku,
-      price,
-      currency,
-      ingredient_measures_attributes, /* eslint-disable-line camelcase */
-    };
 
     const providers = await getProviders();
     this.providersNames = providers.data.data.map((provider) => provider.attributes.name);

--- a/app/javascript/components/ingredients/search-market-ingredients.vue
+++ b/app/javascript/components/ingredients/search-market-ingredients.vue
@@ -127,7 +127,7 @@ export default {
     addMarketIngredient(productIdx) {
       const productInfo = this.productsByMarket[this.market].products[productIdx];
       const productForm = {
-        providerName: this.productsByMarket[this.market].provider.name,
+        provider_name: this.productsByMarket[this.market].provider.name, /* eslint-disable-line camelcase */
         name: productInfo.name,
         sku: null,
         price: productInfo.price,


### PR DESCRIPTION
# ¿Que se hizo?
Al agregar un ingrediente desde el buscador de ingredientes en el supermercado se abre el modal de crear ingredientes para editar los datos que sean necesarios antes de agregar el ingrediente.
# QA
Agregar un ingrediente desde algun supermercado y que se abra el modal con los datos ya llenados para ese ingrediente. Que se puedan editar y se cree bien el ingrediente en bdd. Despues de crearlo puede ser eliminado o editado. Ademas que no debiese afectar a la creacion y edicion de otros ingredientes.