### PR TITLE
Fix(details-dropdown-float): dropdown closes when clicked outside and quantity of ingredient can be float

### DIFF
--- a/app/javascript/components/base/base-dropdown.vue
+++ b/app/javascript/components/base/base-dropdown.vue
@@ -2,7 +2,7 @@
   <div class="relative">
     <button
       class="focus:outline-none"
-      @click="openDropdown"
+      @click="toggleDropdown"
     >
       <div class="flex justify-between items-center min-w-max w-16">
         <div> {{ selectedElement }} </div>
@@ -46,9 +46,19 @@ export default {
       selectedElement: this.elements[0],
     };
   },
+  mounted() {
+    document.addEventListener('click', this.closeDropdown);
+  },
+  unmounted() {
+    document.removeEventListener('click', this.closeDropdown);
+  },
   methods: {
-    openDropdown() {
+    toggleDropdown() {
       this.active = !this.active;
+    },
+    closeDropdown(event) {
+      if (event.target === this.$el || this.$el.contains(event.target)) return;
+      this.active = false;
     },
     selectElement(element) {
       this.selectedElement = element;

--- a/app/javascript/components/recipes/base/recipe-ingredients.vue
+++ b/app/javascript/components/recipes/base/recipe-ingredients.vue
@@ -46,8 +46,7 @@
               :recipe-ingredient-idx="idx"
               :recipe-ingredient-attrs="recipeIngredient.attributes"
               @delete-ingredient="deleteIngredient"
-              @increase-quantity="increaseQuantity"
-              @decrease-quantity="decreaseQuantity"
+              @change-quantity="changeQuantity"
               @change-measure="changeMeasure"
             >
               {{ recipeIngredient.attributes.ingredient.name }}
@@ -127,12 +126,10 @@ export default {
     deleteIngredient(recipeIngredientIdx) {
       this.$emit('delete-ingredient', recipeIngredientIdx);
     },
-    increaseQuantity(recipeIngredientIdx) {
-      this.$emit('increase-quantity', recipeIngredientIdx);
+    changeQuantity(recipeIngredientIdx, ingredientQuantityData) {
+      this.$emit('change-quantity', recipeIngredientIdx, ingredientQuantityData);
     },
-    decreaseQuantity(recipeIngredientIdx) {
-      this.$emit('decrease-quantity', recipeIngredientIdx);
-    },
+
     changeMeasure(measure, recipeIngredientIdx) {
       this.$emit('change-measure', measure, recipeIngredientIdx);
     },
@@ -141,7 +138,6 @@ export default {
 
       return recipeIngredient.ingredientQuantity * this.unitaryPrice(recipeIngredient);
     },
-
     unitaryPrice(recipeIngredient) {
       const defaultQuantity = recipeIngredient.ingredient.otherMeasures.data.map(element =>
         element.attributes).filter(element =>

--- a/app/javascript/components/recipes/base/selected-ingredient-card.vue
+++ b/app/javascript/components/recipes/base/selected-ingredient-card.vue
@@ -10,7 +10,7 @@
           {{ $t('msg.recipes.price') }} {{ $t('msg.recipes.unitary') }}
         </div>
         <div class="h-5 font-hind font-normal text-sm text-black">
-          $ {{ unitaryPrice }} CLP por
+          {{ unitaryPrice | currency }}  por
           {{ recipeIngredientAttrs.ingredientMeasure }}
         </div>
       </div>
@@ -28,11 +28,10 @@
             src="../../../../assets/images/minus-svg.svg"
           >
         </button>
-        <div
-          class="w-5 h-5 bg-gray-20 text-xs text-center my-auto"
+        <input
+          class="w-8 h-5 bg-gray-20 text-xs text-center my-auto"
+          v-model="ingredientQuantityData"
         >
-          {{ recipeIngredientAttrs.ingredientQuantity }}
-        </div>
         <button
           class="w-3 h-3 rounded-sm bg-gray-200 shadow-sm ml-0.5 focus:outline-none"
           @click="increaseQuantity"
@@ -78,15 +77,22 @@ export default {
     recipeIngredientIdx: { type: Number, required: true },
     recipeIngredientAttrs: { type: Object, required: true },
   },
+
+  data() {
+    return {
+      ingredientQuantityData: this.recipeIngredientAttrs.ingredientQuantity,
+    };
+  },
+
   methods: {
     deleteIngredient() {
       this.$emit('delete-ingredient', this.recipeIngredientIdx);
     },
     increaseQuantity() {
-      this.$emit('increase-quantity', this.recipeIngredientIdx);
+      this.ingredientQuantityData = parseFloat(this.ingredientQuantityData) + 1;
     },
     decreaseQuantity() {
-      this.$emit('decrease-quantity', this.recipeIngredientIdx);
+      this.ingredientQuantityData = parseFloat(this.ingredientQuantityData) - 1;
     },
     changeMeasure(measure) {
       this.$emit('change-measure', measure, this.recipeIngredientIdx);
@@ -120,6 +126,12 @@ export default {
       }
 
       return ingredientUnits;
+    },
+  },
+
+  watch: {
+    ingredientQuantityData() {
+      this.$emit('change-quantity', this.recipeIngredientIdx, this.ingredientQuantityData);
     },
   },
 };

--- a/app/javascript/components/recipes/edit/recipe-edit.vue
+++ b/app/javascript/components/recipes/edit/recipe-edit.vue
@@ -60,8 +60,7 @@
         :recipe-ingredients="recipe.recipeIngredients.data"
         @add-ingredient="addIngredient"
         @delete-ingredient="deleteIngredient"
-        @increase-quantity="increaseQuantity"
-        @decrease-quantity="decreaseQuantity"
+        @change-quantity="changeQuantity"
         @change-measure="changeMeasure"
       />
       <!-- pasos -->
@@ -157,16 +156,8 @@ export default {
       }
       this.recipe.recipeIngredients.data.splice(recipeIngredientIdx, 1);
     },
-    increaseQuantity(recipeIngredientIdx) {
-      this.recipe.recipeIngredients.data[recipeIngredientIdx].attributes.ingredientQuantity += 1;
-    },
-    decreaseQuantity(recipeIngredientIdx) {
-      if (this.recipe.recipeIngredients.data[recipeIngredientIdx].attributes.ingredientQuantity === 1) {
-        this.deleteIngredient(recipeIngredientIdx);
-
-        return;
-      }
-      this.recipe.recipeIngredients.data[recipeIngredientIdx].attributes.ingredientQuantity -= 1;
+    changeQuantity(recipeIngredientIdx, ingredientQuantityData) {
+      this.recipe.recipeIngredients.data[recipeIngredientIdx].attributes.ingredientQuantity = ingredientQuantityData;
     },
     changeMeasure(measure, recipeIngredientIdx) {
       this.recipe.recipeIngredients.data[recipeIngredientIdx].attributes.ingredientMeasure = measure;

--- a/app/javascript/components/recipes/new/recipe-create.vue
+++ b/app/javascript/components/recipes/new/recipe-create.vue
@@ -60,8 +60,7 @@
         :recipe-ingredients="recipe.recipeIngredients.data"
         @add-ingredient="addIngredient"
         @delete-ingredient="deleteIngredient"
-        @increase-quantity="increaseQuantity"
-        @decrease-quantity="decreaseQuantity"
+        @change-quantity="changeQuantity"
         @change-measure="changeMeasure"
       />
       <!-- pasos -->
@@ -150,16 +149,8 @@ export default {
       }
       this.recipe.recipeIngredients.data.splice(recipeIngredientIdx, 1);
     },
-    increaseQuantity(recipeIngredientIdx) {
-      this.recipe.recipeIngredients.data[recipeIngredientIdx].attributes.ingredientQuantity += 1;
-    },
-    decreaseQuantity(recipeIngredientIdx) {
-      if (this.recipe.recipeIngredients.data[recipeIngredientIdx].attributes.ingredientQuantity === 1) {
-        this.deleteIngredient(recipeIngredientIdx);
-
-        return;
-      }
-      this.recipe.recipeIngredients.data[recipeIngredientIdx].attributes.ingredientQuantity -= 1;
+    changeQuantity(recipeIngredientIdx, ingredientQuantityData) {
+      this.recipe.recipeIngredients.data[recipeIngredientIdx].attributes.ingredientQuantity = ingredientQuantityData;
     },
     changeMeasure(measure, recipeIngredientIdx) {
       this.recipe.recipeIngredients.data[recipeIngredientIdx].attributes.ingredientMeasure = measure;


### PR DESCRIPTION
# Lo que se hizo
- Arreglar el base dropdown para que se pueda cerrar cuando se hace click en cualquier lugar fuera de él.
- Ahora la cantidad de un ingrediente en una receta puede ser decimal

# QA
## Para el base dropdown:
- Ir a Recetas --> Agregar receta --> Agregar algún ingrediente. En ingredientes seleccionados, si se abre el dropdown con las unidades, al hacer click en cuaquier parte de la página, se cierra. 
- Lo mismo que antes, pero en Show de alguna receta --> Editar.
## Para la cantidad decimal:
- Ir a Recetas --> Agregar receta --> Agregar algún ingrediente. En la cantidad se puede ingresar directamente un número o usar los botones +/-, usar decimal para probar (por ejemplo, ingresar 0.5, luego si se usa el + debería aumentar a 1.5). En caso de Agregar algo como "1." quedará como "1". Agregar la receta, luego si se va a su show, se ven los datos correctamente como decimales, y el precio es calculado correctamente considerando que son floats. 
- Ir a Editar esa receta --> los datos se ven bien como decimal y al editar también se puede cambiar a un dato float, de la misma forma que en crear.
