### PR TITLE
Web providers bank account

### DIFF
--- a/app/assets/images/credit-card-svg.svg
+++ b/app/assets/images/credit-card-svg.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+</svg>

--- a/app/javascript/components/providers/index/provider-item.vue
+++ b/app/javascript/components/providers/index/provider-item.vue
@@ -203,13 +203,13 @@
       :ok-button-label="$t('msg.providers.copy')"
       :cancel-button-label="$t('msg.cancel')"
     >
-      <p id="copyy">
-        {{ provider.name }}
+      <p>
+        {{ provider.contactName }}
       </p>
-      <p>78.234.241-3</p>
-      <p>Banco de Chile</p>
-      <p>Cuenta corriente</p>
-      <p>7800023546</p>
+      <p>{{ provider.contactRut }}</p>
+      <p>{{ provider.bankName }}</p>
+      <p>{{ provider.accountType }}</p>
+      <p>{{ provider.accountNumber }}</p>
       <p>{{ provider.email }}</p>
     </base-modal>
   </div>

--- a/app/javascript/components/providers/index/provider-item.vue
+++ b/app/javascript/components/providers/index/provider-item.vue
@@ -203,14 +203,22 @@
       :ok-button-label="$t('msg.providers.copy')"
       :cancel-button-label="$t('msg.cancel')"
     >
-      <p>
-        {{ provider.contactName }}
-      </p>
-      <p>{{ provider.contactRut }}</p>
-      <p>{{ provider.bankName }}</p>
-      <p>{{ provider.accountType }}</p>
-      <p>{{ provider.accountNumber }}</p>
-      <p>{{ provider.email }}</p>
+      <div
+        v-if="provider.contactName && provider.contactRut && provider.bankName &&
+          provider.accountType && provider.accountNumber && provider.email"
+      >
+        <p>
+          {{ provider.contactName }}
+        </p>
+        <p>{{ provider.contactRut }}</p>
+        <p>{{ provider.bankName }}</p>
+        <p>{{ provider.accountType }}</p>
+        <p>{{ provider.accountNumber }}</p>
+        <p>{{ provider.email }}</p>
+      </div>
+      <div v-else>
+        <p> {{ $t('msg.providers.noTransferData') }} </p>
+      </div>
     </base-modal>
   </div>
 </template>

--- a/app/javascript/components/providers/index/provider-item.vue
+++ b/app/javascript/components/providers/index/provider-item.vue
@@ -76,8 +76,8 @@
               >
             </div>
             <!-- Texto -->
-            <p class="flex text-base items-center text-gray-400 underline">
-              Página Web
+            <p class="flex text-base items-center text-gray-400">
+              {{ $t('msg.providers.webpageUrl') }}
             </p>
           </div>
           <!-- Link -->
@@ -87,6 +87,30 @@
           >
             {{ provider.webpageUrl }}
           </div>
+        </div>
+        <!-- Datos bancarios -->
+        <div class="flex flex-row items-start flex-none order-none w-full justify-between">
+          <div class="flex flex-row flex-none items-center order-none w-48">
+            <!-- Icono -->
+            <div class="w-4 h-4 flex-none m-1.5">
+              <img
+                svg-inline
+                src="../../../../assets/images/credit-card-svg.svg"
+                class="w-4 h-4"
+              >
+            </div>
+            <!-- Texto -->
+            <p class="flex text-base items-center text-gray-400">
+              {{ $t('msg.providers.bank') }}
+            </p>
+          </div>
+          <!-- Boton ver datos -->
+          <button
+            class="flex items-center text-black text-right justify-items-end max-w-full bg-gray-100 border-2 rounded px-1"
+            @click="toggleBankAccount"
+          >
+            {{ $t('msg.providers.see') }}
+          </button>
         </div>
         <!-- Minimo Compra -->
         <div class="flex flex-row items-start flex-none order-none w-full justify-between">
@@ -101,7 +125,7 @@
             </div>
             <!-- Texto -->
             <p class="flex text-base items-center text-gray-400">
-              Mínimo de Compra
+              {{ $t('msg.providers.minimumPurchase') }}
             </p>
           </div>
           <!-- Minimo -->
@@ -122,22 +146,23 @@
             </div>
             <!-- Texto -->
             <p class="flex text-base items-center text-gray-400">
-              Tiempo de Despacho
+              {{ $t('msg.providers.deliveryDays') }}
             </p>
           </div>
           <!-- Tiempo -->
           <p class="flex items-center text-black flex-none order-1 text-right justify-items-end">
-            {{ provider.deliveryDays }} días
+            {{ provider.deliveryDays }} {{ $t('msg.providers.days') }}
           </p>
         </div>
       </div>
-      <div class="flex flex-row items-start flex-none order-2 self-stretch w-full justify-between mx-2">
+      <!-- botones -->
+      <div class="flex flex-row items-start flex-none order-2 self-stretch w-80 justify-between mx-2">
         <div>
           <button
             class="flex flex-row items-center justify-center bg-green-500 hover:bg-green-700 text-white rounded flex-none order-1 flex-grow-1 px-2"
             @click="toggleDelModal"
           >
-            Eliminar Proveedor
+            {{ $t('msg.providers.delete') }}
           </button>
         </div>
         <div>
@@ -145,7 +170,7 @@
             class="flex flex-row items-center justify-center bg-white hover:bg-gray-300 text-black rounded flex-none order-1 flex-grow-1 px-2"
             @click="toggleEditModal"
           >
-            Editar Proveedor
+            {{ $t('msg.providers.edit') }}
           </button>
         </div>
       </div>
@@ -170,6 +195,23 @@
     >
       <p>{{ $t('msg.providers.deleteMsg') }}</p>
     </base-modal>
+    <base-modal
+      @ok="copyBankAccount"
+      @cancel="toggleBankAccount"
+      v-if="showBankAccount"
+      :title="$t('msg.providers.bank')"
+      :ok-button-label="$t('msg.providers.copy')"
+      :cancel-button-label="$t('msg.cancel')"
+    >
+      <p id="copyy">
+        {{ provider.name }}
+      </p>
+      <p>78.234.241-3</p>
+      <p>Banco de Chile</p>
+      <p>Cuenta corriente</p>
+      <p>7800023546</p>
+      <p>{{ provider.email }}</p>
+    </base-modal>
   </div>
 </template>
 
@@ -189,6 +231,7 @@ export default {
       showingDetails: false,
       showingDel: false,
       showingEdit: false,
+      showBankAccount: false,
       providerToDelete: {},
       providerToEdit: {},
     };
@@ -206,6 +249,12 @@ export default {
       this.showingEdit = !this.showingEdit;
       this.providerToEdit = this.provider;
     },
+    toggleBankAccount() {
+      this.showBankAccount = !this.showBankAccount;
+    },
+    copyBankAccount() {
+      console.log('copiando los datos bancarios');
+    },
     async editProvider(provider) {
       this.toggleEditModal();
       try {
@@ -215,7 +264,6 @@ export default {
         this.errorResponse(error);
       }
     },
-
     async deleteProvider() {
       try {
         const response = await deleteProvider(this.providerToDelete.id);

--- a/app/javascript/components/providers/index/providers-form.vue
+++ b/app/javascript/components/providers/index/providers-form.vue
@@ -128,42 +128,42 @@
               <!-- contact name -->
               <input
                 class="appearance-none block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
-                id="provider-bankAccount-name"
+                id="provider-contactName"
                 type="text"
                 :placeholder="$t('msg.providers.bankAccount.name')"
-                v-model="form.bankAccountName"
+                v-model="form.contactName"
               >
               <!-- account rut -->
               <input
                 class="appearance-none block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
-                id="provider-bankAccount-rut"
+                id="provider-contactRut"
                 type="text"
                 :placeholder="$t('msg.providers.bankAccount.rut')"
-                v-model="form.bankAccountRut"
+                v-model="form.contactRut"
               >
               <!-- bank name -->
               <input
                 class="appearance-none block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
-                id="provider-bankAccount-bank"
+                id="provider-bankName"
                 type="text"
                 :placeholder="$t('msg.providers.bankAccount.bank')"
-                v-model="form.bankAccountBank"
+                v-model="form.bankName"
               >
               <!-- account type -->
               <input
                 class="appearance-none block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
-                id="provider-bankAccount-type"
+                id="provider-accountType"
                 type="text"
                 :placeholder="$t('msg.providers.bankAccount.type')"
-                v-model="form.bankAccountType"
+                v-model="form.accountType"
               >
               <!-- account number -->
               <input
                 class="appearance-none block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
-                id="provider-bankAccount-number"
+                id="provider-accountNumber"
                 type="text"
                 :placeholder="$t('msg.providers.bankAccount.number')"
-                v-model="form.bankAccountNumber"
+                v-model="form.accountNumber"
               >
             </div>
           </div>
@@ -233,7 +233,6 @@
               >
             </div>
           </div>
-
           <div class="flex flex-wrap -mx-3 mb-6">
             <div class="w-full md:w-1/2 px-3 mb-6 md:mb-0">
               <!--WebpageUrl -->
@@ -252,7 +251,7 @@
               >
             </div>
             <div class="relative">
-              <!--DeliberyDays -->
+              <!--DeliveryDays -->
               <label
                 class="block text-gray-700 text-sm font-bold mb-2"
                 for="provider-deliveryDays"
@@ -286,6 +285,57 @@
               >
             </div>
           </div>
+          <!-- Datos bancarios -->
+          <div class="flex flex-wrap -mx-3 mb-6">
+            <div class="w-full px-3">
+              <label
+                class="block text-gray-700 text-sm font-bold mb-2"
+                for="provider-bankAccount"
+              >
+                {{ $t('msg.providers.bank') }}
+              </label>
+              <!-- contact name -->
+              <input
+                class="appearance-none block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
+                id="provider-contactName"
+                type="text"
+                :placeholder="$t('msg.providers.bankAccount.name')"
+                v-model="form.contactName"
+              >
+              <!-- account rut -->
+              <input
+                class="appearance-none block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
+                id="provider-contactRut"
+                type="text"
+                :placeholder="$t('msg.providers.bankAccount.rut')"
+                v-model="form.contactRut"
+              >
+              <!-- bank name -->
+              <input
+                class="appearance-none block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
+                id="provider-bankName"
+                type="text"
+                :placeholder="$t('msg.providers.bankAccount.bank')"
+                v-model="form.bankName"
+              >
+              <!-- account type -->
+              <input
+                class="appearance-none block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
+                id="provider-accountType"
+                type="text"
+                :placeholder="$t('msg.providers.bankAccount.type')"
+                v-model="form.accountType"
+              >
+              <!-- account number -->
+              <input
+                class="appearance-none block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
+                id="provider-accountNumber"
+                type="text"
+                :placeholder="$t('msg.providers.bankAccount.number')"
+                v-model="form.accountNumber"
+              >
+            </div>
+          </div>
         </form>
       </div>
     </base-modal>
@@ -312,6 +362,11 @@ export default {
         minimumPurchase: '',
         deliveryDays: '',
         phone: '',
+        contactName: '',
+        contactRut: '',
+        bankName: '',
+        accountType: '',
+        accountNumber: '',
       },
     };
   },
@@ -324,6 +379,11 @@ export default {
       minimumPurchase,
       deliveryDays,
       phone,
+      contactName,
+      contactRut,
+      bankName,
+      accountType,
+      accountNumber,
     } = this.provider;
 
     this.form = {
@@ -333,6 +393,11 @@ export default {
       minimumPurchase,
       deliveryDays,
       phone,
+      contactName,
+      contactRut,
+      bankName,
+      accountType,
+      accountNumber,
     };
   },
 };

--- a/app/javascript/components/providers/index/providers-form.vue
+++ b/app/javascript/components/providers/index/providers-form.vue
@@ -116,6 +116,57 @@
               >
             </div>
           </div>
+          <!-- Datos bancarios -->
+          <div class="flex flex-wrap -mx-3 mb-6">
+            <div class="w-full px-3">
+              <label
+                class="block text-gray-700 text-sm font-bold mb-2"
+                for="provider-bankAccount"
+              >
+                {{ $t('msg.providers.bank') }}
+              </label>
+              <!-- contact name -->
+              <input
+                class="appearance-none block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
+                id="provider-bankAccount-name"
+                type="text"
+                :placeholder="$t('msg.providers.bankAccount.name')"
+                v-model="form.bankAccountName"
+              >
+              <!-- account rut -->
+              <input
+                class="appearance-none block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
+                id="provider-bankAccount-rut"
+                type="text"
+                :placeholder="$t('msg.providers.bankAccount.rut')"
+                v-model="form.bankAccountRut"
+              >
+              <!-- bank name -->
+              <input
+                class="appearance-none block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
+                id="provider-bankAccount-bank"
+                type="text"
+                :placeholder="$t('msg.providers.bankAccount.bank')"
+                v-model="form.bankAccountBank"
+              >
+              <!-- account type -->
+              <input
+                class="appearance-none block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
+                id="provider-bankAccount-type"
+                type="text"
+                :placeholder="$t('msg.providers.bankAccount.type')"
+                v-model="form.bankAccountType"
+              >
+              <!-- account number -->
+              <input
+                class="appearance-none block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
+                id="provider-bankAccount-number"
+                type="text"
+                :placeholder="$t('msg.providers.bankAccount.number')"
+                v-model="form.bankAccountNumber"
+              >
+            </div>
+          </div>
         </form>
       </div>
     </base-modal>

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -129,8 +129,10 @@ export default {
       title: 'Proveedores',
       search: 'Buscar proveedores...',
       name: 'Nombre',
+      rut: 'Rut',
       address: 'Dirección',
       country: 'Pais',
+      days: 'días',
       email: 'Correo',
       webpageUrl: 'Página Web',
       minimumPurchase: 'Mínimo de Compra',
@@ -140,7 +142,16 @@ export default {
       delete: 'Eliminar proveedor',
       edit: 'Editar Proveedor',
       deleteMsg: 'Estás seguro de que deseas eliminar este proveedor?',
-
+      see: 'Ver datos',
+      copy: 'Copiar',
+      bank: 'Cuenta Bancaria',
+      bankAccount: {
+        name: 'Nombre',
+        rut: 'Rut',
+        bank: 'Banco',
+        type: 'Tipo de cuenta',
+        number: 'Número de cuenta',
+      },
     },
   },
 };

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -152,6 +152,7 @@ export default {
         type: 'Tipo de cuenta',
         number: 'Número de cuenta',
       },
+      noTransferData: 'Aún no se tiene esta información',
     },
   },
 };

--- a/app/models/ingredient_measure.rb
+++ b/app/models/ingredient_measure.rb
@@ -16,8 +16,7 @@ end
 #
 # Indexes
 #
-#  index_ingredient_measures_on_ingredient_id           (ingredient_id)
-#  index_ingredient_measures_on_name_and_ingredient_id  (name,ingredient_id) UNIQUE
+#  index_ingredient_measures_on_ingredient_id  (ingredient_id)
 #
 # Foreign Keys
 #

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,11 +23,9 @@ ActiveRecord::Schema.define(version: 2021_06_23_211145) do
     t.bigint "author_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["author_type", "author_id"],
-            name: "index_active_admin_comments_on_author_type_and_author_id"
+    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
     t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
-    t.index ["resource_type", "resource_id"],
-            name: "index_active_admin_comments_on_resource_type_and_resource_id"
+    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"
   end
 
   create_table "admin_users", force: :cascade do |t|
@@ -39,8 +37,7 @@ ActiveRecord::Schema.define(version: 2021_06_23_211145) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token",
-                                      unique: true
+    t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 
   create_table "ingredient_measures", force: :cascade do |t|
@@ -51,8 +48,6 @@ ActiveRecord::Schema.define(version: 2021_06_23_211145) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "primary", default: false
     t.index ["ingredient_id"], name: "index_ingredient_measures_on_ingredient_id"
-    t.index ["name", "ingredient_id"], name: "index_ingredient_measures_on_name_and_ingredient_id",
-                                       unique: true
   end
 
   create_table "ingredients", force: :cascade do |t|


### PR DESCRIPTION
# Contexto
Está la sección de proovedores pero falta un lugar donde s epuedan ver los datos bancarios

# Lo que hice
- Agregar al form de proveedores campos para agregar los datos bancarios
- Agregar botón a la tarjeta de proveedores para ver datos bancarios

# QA
- ir a /providers
- Agregar un nuevo proveedor y rellenar los campos correspondientes a datos bancarios
- Ver la tarjeta del nuevo proveedor y apretar "ver datos"
- Apretar "editar" en la tarjeta de proveedores y cambiar alguno de los daos bancarios y comprobar nuevamente en "ver datos" que estos se hayan modificado correctamente

# Lo que falta
- Dar funcionalidad al botón "Copiar" en el popup con los datos, para que estos queden copiados en el clipboard y se puedan pegar al realizar una transferencia

Así se debería ver el form para agregar un proveedor
![Captura de Pantalla 2021-06-23 a la(s) 18 27 48](https://user-images.githubusercontent.com/48369511/123299846-eb96e200-d4e7-11eb-8960-8643fc5af907.png)

Así se ve la tarjeta con una sección para ver los datos bancarios 
![Captura de Pantalla 2021-06-24 a la(s) 12 25 22](https://user-images.githubusercontent.com/48369511/123299926-ffdadf00-d4e7-11eb-91a5-fd348a263a70.png)

Así se debería ver el popup de los datos bancarios ingresados
![Captura de Pantalla 2021-06-23 a la(s) 18 28 03](https://user-images.githubusercontent.com/48369511/123299985-11bc8200-d4e8-11eb-9c1c-adc550090549.png)

