### PR TITLE
fix(sessions-bug): fix bug when session was closed after a while

### DIFF
--- a/app/javascript/components/layout/top-navbar.vue
+++ b/app/javascript/components/layout/top-navbar.vue
@@ -12,7 +12,7 @@
     <!--Right buttons -->
     <div class="w-full flex-grow lg:flex lg:items-end lg:w-auto justify-end pr-5">
       <!--Logged -->
-      <template v-if="logged">
+      <template v-if="isCurrentUser">
         <button
           class="text-lg px-4 py-2 text-white hover:bg-gray-900 mt-4 lg:mt-0 focus:outline-none"
           @click="logout"
@@ -45,10 +45,8 @@ import { logoutUser } from './../../api/users.js';
 
 export default {
 
-  computed: {
-    logged() {
-      return localStorage.getItem('token');
-    },
+  props: {
+    isCurrentUser: { type: Boolean, required: true },
   },
 
   methods: {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
     <% end %>
 
     <div id="vue-app">
-      <top-navbar></top-navbar>
+      <top-navbar :is-current-user=<%= current_user.present? %>></top-navbar>
         <%= yield %>
     </div>
   </body>


### PR DESCRIPTION
# Problema

Antes pasaba que después de usar la aplicación, en unas horas y un par de días, cuando uno se mete de nuevo había una "descoordinación" entre el topnavbar y lo que rendereaba la aplicación en términos de las sesiones:

![image](https://user-images.githubusercontent.com/26123660/123332014-f9f7f480-d50d-11eb-8fb0-0a56050bee49.png)

# Lo que se hizo

Usar en el top navbar la misma forma que se tiene para saber si el usuario está logeado o no que para el resto de las páginas (current_user)

# QA

El error es un poco complejo de replicar por que se tiene que esperar un rato (no sabemos exactamente cuanto) para saber si se solucionó el error. Por el momento, por lo menos basta con que el resto siga funcionando igual sin problemas.