### PR TITLE
refactor(shopping-list): show primary measure instead

### DIFF
--- a/app/controllers/api/v1/menus_controller.rb
+++ b/app/controllers/api/v1/menus_controller.rb
@@ -106,18 +106,10 @@ class Api::V1::MenusController < Api::V1::BaseController
   def menu_ingredient_to_json(ingredient:, accumulated_quantity:)
     {
       name: ingredient.name,
-      measure: ingredient.ingredient_measure,
+      measure: ingredient.measure,
       quantity: accumulated_quantity,
-      total_price: get_price_of_ingredient(ingredient) * accumulated_quantity
+      total_price: ingredient.price.to_f / ingredient.quantity * accumulated_quantity
     }
-  end
-
-  def get_price_of_ingredient(ingredient)
-    ingredient.ingredient_measures.each do |ingredient_measure|
-      next unless ingredient_measure.name == ingredient.ingredient_measure
-
-      return ingredient.price / ingredient_measure.quantity
-    end
   end
 
   def format_providers_with_ingredients(providers_with_ingredients)
@@ -130,7 +122,11 @@ class Api::V1::MenusController < Api::V1::BaseController
   end
 
   def menu_ingredient_quantity(record)
-    record.recipe_quantity.to_i * record.ingredient_quantity.to_i
+    ingredient_quantity = record.factor_of_default_quantity_by_measure(
+      record.ingredient_measure
+    ) * record.ingredient_quantity.to_f
+
+    record.recipe_quantity.to_f * ingredient_quantity
   end
 
   def menu_params

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -25,7 +25,7 @@ class Ingredient < ApplicationRecord
     default_quantity = default_measure&.quantity
     return if default_quantity.blank?
 
-    default_quantity / ingredient_measures.find_by(name: measure_name).quantity
+    default_quantity.to_f / ingredient_measures.find_by(name: measure_name).quantity
   end
 
   def default_measure

--- a/spec/integration/api/v1/menus_spec.rb
+++ b/spec/integration/api/v1/menus_spec.rb
@@ -215,10 +215,10 @@ describe 'Api::V1::Menus', swagger_doc: 'v1/swagger.json' do
     let!(:existent_menu) { create(:menu, recipes: [first_recipe, second_recipe], user: user) }
     let(:id) { existent_menu.id }
 
-    def ingredient_hash(name, quantity)
+    def ingredient_hash(name, quantity, measure)
       hash_including(
-        measure: kind_of(String), name: name,
-        quantity: quantity, total_price: kind_of(Integer)
+        measure: measure, name: name,
+        quantity: quantity, total_price: kind_of(Float)
       )
     end
 
@@ -226,9 +226,9 @@ describe 'Api::V1::Menus', swagger_doc: 'v1/swagger.json' do
       {
         provider: "Jumbo",
         ingredients: match_array([
-                                   ingredient_hash("First", 9),
-                                   ingredient_hash("Second", 30),
-                                   ingredient_hash("Third", 6)
+                                   ingredient_hash("First", 18, 'Unidades'),
+                                   ingredient_hash("Second", 30, 'L'),
+                                   ingredient_hash("Third", 6, 'Unidades')
                                  ])
       }
     end
@@ -257,12 +257,16 @@ describe 'Api::V1::Menus', swagger_doc: 'v1/swagger.json' do
         )
 
         IngredientMeasure.create!(name: 'Kg', quantity: 3, ingredient_id: first_ingredient.id)
+        IngredientMeasure.create!(
+          name: 'Unidades', quantity: 6,
+          ingredient_id: first_ingredient.id, primary: true
+        )
         IngredientMeasure.create!(name: 'L', quantity: 5, ingredient_id: second_ingredient.id)
         IngredientMeasure.create!(name: 'Unidades', quantity: 2, ingredient_id: third_ingredient.id)
       end
       # rubocop:enable Rails/SkipsModelValidations
 
-      response '200', 'shopping list grouped by provider' do
+      response '200', 'shopping list grouped by provider with default measure' do
         run_test! do |response|
           expect(JSON.parse(response.body).first.deep_symbolize_keys).to match(expected_response)
         end


### PR DESCRIPTION
Corrijo la forma en que muestro la shopping list. Antes si en una receta ponía que necesitaba 2 unidades de tomate, pero la unidad por default (de inventario) estaba en kilos, igual se mostraba en la lista de compras "2 unidades de tomate"

Ahora siempre la shopping-list (y el excel que se puede generar) hace la conversión de unidades a las primarias, para que calce con el inventario.

### QA

 Crear un ingrediente con distintas measures, una receta que tenga a ese ingrediente con una measure, y otra receta que tenga ese ingrediente con otra measure distinta.

Crear un menú con ambas recetas. El shopping list (carrito) debería tener la suma de ambos ingredientes en una sola unidad.