### PR TITLE
fix(ingredients/recipes): bugs modal market ingredients and steps in recipe edit

### DIFF
--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -238,21 +238,8 @@ export default {
 
     async addMarketIngredient(productForm) {
       this.toggleSearchIngredientsModal();
-      this.loading = true;
-      try {
-        const {
-          data:
-            {
-              data: { id, attributes },
-            },
-        } = await postIngredient(productForm);
-        const ingredientToAdd = { id, ...attributes };
-        this.ingredients.push(ingredientToAdd);
-      } catch (error) {
-        this.error = error;
-      } finally {
-        this.loading = false;
-      }
+      this.toggleAddModal();
+      this.marketIngredient = productForm;
     },
     addInventoryToIngredient(ingredientsInfo, id) {
       this.ingredients.forEach(elem => {

--- a/app/javascript/components/recipes/base/recipe-steps.vue
+++ b/app/javascript/components/recipes/base/recipe-steps.vue
@@ -110,8 +110,8 @@ export default {
     return {
       newStepDescription: null,
       error: '',
-      modifiedRecipeSteps: [],
-      recipeStepsSet: new Set(),
+      modifiedRecipeSteps: this.recipeSteps.map((step) => ({ step, isEditing: false, editingStepDescription: '' })),
+      recipeStepsSet: new Set([...this.recipeSteps]),
     };
   },
   watch: {


### PR DESCRIPTION
**Contexto:** se arreglaron los siguientes bugs (muy pocas lineas)
- Al querer agregar ingredientes vía mercado (API cornershop) no se estaba mostrando el modal para editar sus parámetros antes de guardarlo.
- Al entrar a editar una receta, los _steps_ existentes no se mostraban hasta que uno agregaba uno nuevo.

Pd no hay problema con que haya eliminado lineas del spinner (en _Ingredients-container_) porque igual eso se hace después al terminar de agregar lo que viene de la API (en el _addIngredient_).

**QA**
- Al agregar un ingrediente vía mercado, se debería poder editar TODOS sus parámetros, y luego agregarse (también se debería poder cancelar el agregar). Después se debería poder editar y/o eliminar sin ningún problema.
- Al entrar a editar una receta, deberían visualizarse las existentes, y no debería haber ningún problema editando/eliminando una. Al terminar de editar, en el show debería verse bien lo editado.
