### PR TITLE
feat(delete-warning): add critical associations to ingredients and recipes delete warning

### DIFF
--- a/app/javascript/api/ingredients.js
+++ b/app/javascript/api/ingredients.js
@@ -36,5 +36,17 @@ async function searchCornershopIngredients(query) {
     )
   );
 }
+function getCriticalAssociations(ingredientId) {
+  return (client
+    .get(`/ingredients/${ingredientId}/critical-associations`, {
+    }));
+}
 
-export { getIngredients, postIngredient, deleteIngredient, editIngredient, searchCornershopIngredients };
+export {
+  getIngredients,
+  postIngredient,
+  deleteIngredient,
+  editIngredient,
+  searchCornershopIngredients,
+  getCriticalAssociations,
+};

--- a/app/javascript/api/recipes.js
+++ b/app/javascript/api/recipes.js
@@ -38,4 +38,10 @@ function getRecipeIngredients(recipeId) {
     }));
 }
 
-export { getRecipes, getRecipe, deleteRecipe, postRecipe, updateRecipe, getRecipeIngredients };
+function getCriticalAssociations(recipeId) {
+  return (client
+    .get(`/recipes/${recipeId}/critical-associations`, {
+    }));
+}
+
+export { getRecipes, getRecipe, deleteRecipe, postRecipe, updateRecipe, getRecipeIngredients, getCriticalAssociations };

--- a/app/javascript/components/base/base-one-column-table.vue
+++ b/app/javascript/components/base/base-one-column-table.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="max-h-48 overflow-auto">
+    <table class="mt-4 min-w-full">
+      <thead>
+        <tr class="bg-gray-200 text-gray-600 uppercase text-sm leading-normal">
+          <th class="py-3 px-6 text-left">
+            {{ header }}
+          </th>
+        </tr>
+      </thead>
+      <tbody class="text-black text-sm font-light">
+        <tr
+          v-for="row in rows"
+          :key="row"
+          class="border-b border-gray-200"
+        >
+          <td class="py-3 px-6 text-left">
+            <p class="font-medium">
+              {{ row }}
+            </p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    header: { type: String, required: true },
+    rows: { type: Array, required: true },
+  },
+};
+</script>

--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -131,7 +131,18 @@
         :ok-button-label="$t('msg.yesDelete')"
         :cancel-button-label="$t('msg.cancel')"
       >
-        <p>{{ $t('msg.ingredients.deleteMsg') }}</p>
+        <!-- Critical associations -->
+        <div v-if="criticalAssociations.length > 0">
+          <p>{{ $t('msg.ingredients.associationWarning') }}</p>
+          <base-one-column-table
+            :header="$t('msg.recipes.title')"
+            :rows="criticalAssociations"
+          />
+        </div>
+        <!-- Delete msg -->
+        <p class="mt-4">
+          {{ $t('msg.ingredients.deleteMsg') }}
+        </p>
       </base-modal>
     </div>
   </div>
@@ -140,7 +151,8 @@
 <script>
 
 import Vue from 'vue';
-import { getIngredients, postIngredient, deleteIngredient, editIngredient } from './../../api/ingredients.js';
+import { getIngredients, postIngredient, deleteIngredient,
+  editIngredient, getCriticalAssociations } from './../../api/ingredients.js';
 import IngredientsForm from './ingredients-form';
 import IngredientsTable from './ingredients-table';
 import SearchMarketIngredients from './search-market-ingredients';
@@ -159,6 +171,7 @@ export default {
       ingredients: [],
       marketIngredient: undefined,
       searchQuery: '',
+      criticalAssociations: [],
       error: '',
     };
   },
@@ -222,6 +235,18 @@ export default {
     toggleDelModal(ingredient) {
       this.showingDel = !this.showingDel;
       this.ingredientToDelete = ingredient;
+      if (this.showingDel) {
+        this.getIngredientAssociations(ingredient.id);
+      }
+    },
+
+    async getIngredientAssociations(ingredientId) {
+      try {
+        const response = await getCriticalAssociations(ingredientId);
+        this.criticalAssociations = response.data.recipes.map((element) => element.name);
+      } catch (error) {
+        this.error = error;
+      }
     },
 
     // eslint-disable-next-line max-statements

--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -132,17 +132,25 @@
         :cancel-button-label="$t('msg.cancel')"
       >
         <!-- Critical associations -->
-        <div v-if="criticalAssociations.length > 0">
-          <p>{{ $t('msg.ingredients.associationWarning') }}</p>
-          <base-one-column-table
-            :header="$t('msg.recipes.title')"
-            :rows="criticalAssociations"
-          />
+        <span
+          class="flex my-auto w-8 h-8 pl-2"
+          v-if="loadingAssociations"
+        >
+          <base-spinner />
+        </span>
+        <div v-else>
+          <div v-if="criticalAssociations.length > 0">
+            <p>{{ $t('msg.ingredients.associationWarning') }}</p>
+            <base-one-column-table
+              :header="$t('msg.recipes.title')"
+              :rows="criticalAssociations"
+            />
+          </div>
+          <!-- Delete msg -->
+          <p class="mt-4">
+            {{ $t('msg.ingredients.deleteMsg') }}
+          </p>
         </div>
-        <!-- Delete msg -->
-        <p class="mt-4">
-          {{ $t('msg.ingredients.deleteMsg') }}
-        </p>
       </base-modal>
     </div>
   </div>
@@ -162,6 +170,7 @@ export default {
   data() {
     return {
       loading: false,
+      loadingAssociations: false,
       showingAdd: false,
       showingSearchIngredients: false,
       showingEdit: false,
@@ -241,11 +250,14 @@ export default {
     },
 
     async getIngredientAssociations(ingredientId) {
+      this.loadingAssociations = true;
       try {
         const response = await getCriticalAssociations(ingredientId);
         this.criticalAssociations = response.data.recipes.map((element) => element.name);
       } catch (error) {
         this.error = error;
+      } finally {
+        this.loadingAssociations = false;
       }
     },
 

--- a/app/javascript/components/recipes/show/recipe-show.vue
+++ b/app/javascript/components/recipes/show/recipe-show.vue
@@ -67,17 +67,25 @@
       :cancel-button-label="$t('msg.cancel')"
     >
       <!-- Critical associations -->
-      <div v-if="criticalAssociations.length > 0">
-        <p>{{ $t('msg.recipes.associationWarning') }}</p>
-        <base-one-column-table
-          :header="$t('msg.menus.title')"
-          :rows="criticalAssociations"
-        />
+      <span
+        class="flex my-auto w-8 h-8 pl-2"
+        v-if="loadingAssociations"
+      >
+        <base-spinner />
+      </span>
+      <div v-else>
+        <div v-if="criticalAssociations.length > 0">
+          <p>{{ $t('msg.recipes.associationWarning') }}</p>
+          <base-one-column-table
+            :header="$t('msg.menus.title')"
+            :rows="criticalAssociations"
+          />
+        </div>
+        <!-- Delete msg -->
+        <p class="mt-4">
+          {{ $t('msg.recipes.deleteMsg') }}
+        </p>
       </div>
-      <!-- Delete msg -->
-      <p class="mt-4">
-        {{ $t('msg.recipes.deleteMsg') }}
-      </p>
     </base-modal>
   </div>
 </template>
@@ -103,6 +111,7 @@ export default {
   data() {
     return {
       loading: false,
+      loadingAssociations: false,
       showingDel: false,
       status: '',
       error: '',
@@ -138,11 +147,14 @@ export default {
       }
     },
     async getIngredientAssociations(recipeId) {
+      this.loadingAssociations = true;
       try {
         const response = await getCriticalAssociations(recipeId);
         this.criticalAssociations = response.data.menus.map((element) => element.name);
       } catch (error) {
         this.error = error;
+      } finally {
+        this.loadingAssociations = false;
       }
     },
     ingredientFinalPrice(quantity, price) {

--- a/app/javascript/components/recipes/show/recipe-show.vue
+++ b/app/javascript/components/recipes/show/recipe-show.vue
@@ -66,14 +66,25 @@
       :ok-button-label="$t('msg.yesDelete')"
       :cancel-button-label="$t('msg.cancel')"
     >
-      <p>{{ $t('msg.recipes.deleteMsg') }}</p>
+      <!-- Critical associations -->
+      <div v-if="criticalAssociations.length > 0">
+        <p>{{ $t('msg.recipes.associationWarning') }}</p>
+        <base-one-column-table
+          :header="$t('msg.menus.title')"
+          :rows="criticalAssociations"
+        />
+      </div>
+      <!-- Delete msg -->
+      <p class="mt-4">
+        {{ $t('msg.recipes.deleteMsg') }}
+      </p>
     </base-modal>
   </div>
 </template>
 
 <script>
 
-import { getRecipe, deleteRecipe } from '../../../api/recipes.js';
+import { getRecipe, deleteRecipe, getCriticalAssociations } from '../../../api/recipes.js';
 import RecipeIngredients from './recipe-ingredients';
 import RecipeInstructions from './recipe-instructions';
 import RecipeInfo from './recipe-info';
@@ -95,6 +106,7 @@ export default {
       showingDel: false,
       status: '',
       error: '',
+      criticalAssociations: [],
       recipe: {
         name: '',
         portions: 0,
@@ -121,6 +133,17 @@ export default {
   methods: {
     toggleDelModal() {
       this.showingDel = !this.showingDel;
+      if (this.showingDel) {
+        this.getIngredientAssociations(this.recipe.id);
+      }
+    },
+    async getIngredientAssociations(recipeId) {
+      try {
+        const response = await getCriticalAssociations(recipeId);
+        this.criticalAssociations = response.data.menus.map((element) => element.name);
+      } catch (error) {
+        this.error = error;
+      }
     },
     ingredientFinalPrice(quantity, price) {
       return (quantity * price);

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -6,7 +6,7 @@ export default {
     add: 'Agregar',
     edit: 'Editar',
     delete: 'Eliminar',
-    yesDelete: 'Sí, Eliminar',
+    yesDelete: 'Sí, eliminar',
     save: 'Guardar',
     cancel: 'Cancelar',
     noElements: 'Aún no tienes',
@@ -45,7 +45,7 @@ export default {
       searchAdd: 'Agregar',
       edit: 'Editar ingrediente',
       delete: 'Eliminar ingrediente',
-      deleteMsg: 'Estás seguro de que deseas eliminar este ingrediente?',
+      deleteMsg: '¿Estás seguro de que deseas eliminar este ingrediente?',
       name: 'Nombre',
       provider: 'Proveedor',
       price: 'Precio',
@@ -57,6 +57,8 @@ export default {
       defaultUnit: 'Unidad por defecto',
       alternativeUnit: 'Unidades alternativas',
       addUnit: 'Agregar Unidad',
+      associationWarning: 'Este ingrediente se encuentra en la(s) siguiente(s) receta(s):',
+      newMeasure: 'Crear la medida',
       inventory: {
         title: 'Inventario',
         editingInventories: 'Editando varios inventarios',
@@ -66,7 +68,6 @@ export default {
         decreaseIn: 'Disminuir en',
         resulting: 'Inventario Resultante',
       },
-      newMeasure: 'Crear la medida',
     },
 
     recipes: {
@@ -76,7 +77,7 @@ export default {
       add: 'Agregar receta',
       edit: 'Editar',
       delete: 'Eliminar',
-      deleteMsg: 'Estás seguro de que deseas eliminar esta receta?',
+      deleteMsg: '¿Estás seguro de que deseas eliminar esta receta?',
       price: 'Precio',
       unitary: 'Unitario',
       minutes: 'minutos',
@@ -112,6 +113,7 @@ export default {
       alertExistingStep: 'Ese paso ya existe',
       alertEmptyStep: 'Ingresa información al paso',
       alertEmptyBasicInformation: 'Falta completar información básica',
+      associationWarning: 'Esta receta se encuentra en el(los) siguiente(s) menú(s):',
     },
 
     menus: {
@@ -160,7 +162,7 @@ export default {
       add: 'Agregar Proveedor',
       delete: 'Eliminar proveedor',
       edit: 'Editar Proveedor',
-      deleteMsg: 'Estás seguro de que deseas eliminar este proveedor?',
+      deleteMsg: '¿Estás seguro de que deseas eliminar este proveedor?',
       see: 'Ver datos',
       copy: 'Copiar',
       bank: 'Cuenta Bancaria',

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,6 +11,7 @@ import DotsDropdown from '../components/base/dots-dropdown.vue';
 import BaseDropdown from '../components/base/base-dropdown.vue';
 import BaseSpinner from '../components/base/base-spinner.vue';
 import TextBox from '../components/base/base-text-box.vue';
+import BaseOneColumnTable from '../components/base/base-one-column-table';
 
 import TopNavbar from '../components/layout/top-navbar.vue';
 import SideNavbar from '../components/layout/side-navbar.vue';
@@ -42,6 +43,7 @@ Vue.component('DotsDropdown', DotsDropdown);
 Vue.component('BaseDropdown', BaseDropdown);
 Vue.component('BaseSpinner', BaseSpinner);
 Vue.component('TextBox', TextBox);
+Vue.component('BaseOneColumnTable', BaseOneColumnTable);
 
 Vue.component('TopNavbar', TopNavbar);
 Vue.component('SideNavbar', SideNavbar);


### PR DESCRIPTION
BASE #134

# Lo que hice

Agregarle al warning de borrar ingredientes y recetas la información de recetas y menús en los que se encontraban.

# QA

1. Agregar algunos ingredientes, recetas y menús
2. Intentar borrar un ingrediente asociado a muchas recetas: se debería ver como la primera imagen, una tabla con las recetas, que tiene un scrollbar y abajo un mensaje de confirmación. 
3. Intentar borrar un ingrediente asociado a una receta: se debería ver como la segunda imagen, una tabla sin scrollbar mostrando la receta y el mensaje de confirmación.
4. Intentar borrar un ingrediente que no está asociado a ninguna receta: como en la tercera imagen, se debería ver solo el mensaje de confirmación.
5. Hacer los pasos 2,3 y 4  para recetas.
6. Obviamente, al dar click a "Sí, eliminar" en cualquiera de los casos, elimina correctamente.

![image](https://user-images.githubusercontent.com/26123660/123710571-fb425d80-d83c-11eb-8fa1-8cb5827d3f7e.png)

![image](https://user-images.githubusercontent.com/26123660/123710790-52e0c900-d83d-11eb-986a-587bfe4630e5.png)

![image](https://user-images.githubusercontent.com/26123660/123710865-74da4b80-d83d-11eb-93dc-658fe4244539.png)

