### PR TITLE
style(see-more-modal): fix style in see more recipes of menu modal

### DIFF
--- a/app/javascript/components/menus/index/menus-table-recipes.vue
+++ b/app/javascript/components/menus/index/menus-table-recipes.vue
@@ -21,19 +21,11 @@
       :ok-button-present="false"
       :cancel-button-label="$t('msg.cancel')"
     >
-      <p class="text-lg">
-        {{ $t('msg.recipes.title') }}:
-      </p>
-      <div
-        v-for="recipe in menu.menuRecipes.data"
-        :key="recipe.attributes.recipe.id"
-        class="flex justify-start cursor-pointer text-gray-700 hover:text-blue-400 hover:bg-blue-100 rounded-md px-2 py-2 my-2"
-      >
-        <span class="bg-gray-600 h-2 w-2 m-2 rounded-full" />
-        <div class="flex-grow text-sm px-2">
-          {{ recipe.attributes.recipeQuantity }} {{ recipe.attributes.recipe.name }}
-        </div>
-      </div>
+      <p>{{ $t('msg.menus.menuRecipes') }}</p>
+      <base-one-column-table
+        :header="$t('msg.recipes.title')"
+        :rows="allMenuRecipes"
+      />
     </base-modal>
   </div>
 </template>
@@ -58,6 +50,10 @@ export default {
     },
     seeMore() {
       return this.menu.menuRecipes.data.length > this.firstRecipes.length;
+    },
+    allMenuRecipes() {
+      return this.menu.menuRecipes.data.map((recipe) =>
+        `${recipe.attributes.recipeQuantity} ${recipe.attributes.recipe.name}`);
     },
   },
 

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -147,6 +147,7 @@ export default {
       reduceInventory: 'Reducir Inventario',
       reduceMsg: '¿Estás seguro que quieres reducir el inventario?',
       yesReduce: 'Reducir',
+      menuRecipes: 'Este menú tiene la(s) siguiente(s) receta(s):',
     },
     providers: {
       title: 'Proveedores',


### PR DESCRIPTION
BASE #137

# Lo que hice

Arreglar el modal de Ver Más Recetas de un menú para que quedara más acorde a las tablas que se muestran en otros modal.

# QA

- Agregar ingredientes y recetas para poder crear un menú, la idea es que el menú tenga por lo menos 4 recetas para que se vea la opción de ver más en la tabla principal de menús.
- Hacer click en Ver más, se debería ver más o menos de la siguiente forma el modal:

![image](https://user-images.githubusercontent.com/26123660/123713156-cbe21f80-d841-11eb-90f0-30acb40c9df1.png)
