### PR TITLE
frondend: fix unitary prices

### DIFF
--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -153,6 +153,7 @@ import MenusTableRecipesQuantity from './menus-table-recipes-quantity';
 import MenusTableRecipes from './menus-table-recipes';
 import MenuShoppingList from './menu-shopping-list';
 import { reduceInventoryApi } from '../../../api/menus';
+import { unitaryPrice } from '../../../utils/recipeUtils.js';
 
 export default {
   components: {
@@ -204,25 +205,11 @@ export default {
       const returnArray = [];
       data.forEach(element => {
         const ingredientQuantity = element.attributes.ingredientQuantity;
-        const ingredientUnitaryPrice = this.unitaryPrice(element.attributes);
-        returnArray.push(ingredientQuantity * ingredientUnitaryPrice);
+        const ingredientUnitaryPrice = unitaryPrice(element.attributes);
+        returnArray.push(Math.round(ingredientQuantity * ingredientUnitaryPrice));
       });
 
       return returnArray;
-    },
-    unitaryPrice(recipeIngredient) {
-      const defaultQuantity = recipeIngredient.ingredient.otherMeasures.data.map(element =>
-        element.attributes).filter(element =>
-        element.name === recipeIngredient.ingredientMeasure)[0].quantity;
-      const price = recipeIngredient.ingredient.price / defaultQuantity;
-      if (this.isInt(price)) {
-        return price;
-      }
-
-      return Math.round(recipeIngredient.ingredient.price / defaultQuantity);
-    },
-    isInt(n) {
-      return n % 1 === 0;
     },
   },
 };

--- a/app/javascript/components/recipes/base/recipe-ingredients.vue
+++ b/app/javascript/components/recipes/base/recipe-ingredients.vue
@@ -86,6 +86,7 @@
 
 <script>
 import { getIngredients } from './../../../api/ingredients.js';
+import { getPriceOfSelectedIngredient } from '../../../utils/recipeUtils.js';
 import addIngredientCard from './add-ingredient-card.vue';
 import selectedIngredientCard from './selected-ingredient-card.vue';
 
@@ -125,7 +126,7 @@ export default {
   computed: {
     recipePrice() {
       return Math.round(this.recipeIngredients.reduce((recipePrice, recipeIngredient) =>
-        recipePrice + this.getPriceOfSelectedIngredient(recipeIngredient.attributes), 0));
+        recipePrice + getPriceOfSelectedIngredient(recipeIngredient.attributes), 0));
     },
     filteredIngredients() {
       if (this.query) {
@@ -151,25 +152,6 @@ export default {
 
     changeMeasure(measure, recipeIngredientIdx) {
       this.$emit('change-measure', measure, recipeIngredientIdx);
-    },
-    getPriceOfSelectedIngredient(recipeIngredient) {
-      if (!recipeIngredient.ingredientQuantity) return 0;
-
-      return recipeIngredient.ingredientQuantity * this.unitaryPrice(recipeIngredient);
-    },
-    unitaryPrice(recipeIngredient) {
-      const defaultQuantity = recipeIngredient.ingredient.otherMeasures.data.map(element =>
-        element.attributes).filter(element =>
-        element.name === recipeIngredient.ingredientMeasure)[0].quantity;
-      const price = recipeIngredient.ingredient.price / defaultQuantity;
-      if (this.isInt(price)) {
-        return price;
-      }
-
-      return Math.round(recipeIngredient.ingredient.price / defaultQuantity);
-    },
-    isInt(n) {
-      return n % 1 === 0;
     },
   },
 };

--- a/app/javascript/components/recipes/base/selected-ingredient-card.vue
+++ b/app/javascript/components/recipes/base/selected-ingredient-card.vue
@@ -70,6 +70,7 @@
 
 <script>
 import baseDropdown from '../../base/base-dropdown.vue';
+import { unitaryPrice } from '../../../utils/recipeUtils.js';
 
 export default {
   components: { baseDropdown },
@@ -103,19 +104,11 @@ export default {
   },
   computed: {
     unitaryPrice() {
-      const defaultQuantity = this.recipeIngredientAttrs.ingredient.otherMeasures.data.map(element =>
-        element.attributes).filter(element =>
-        element.name === this.recipeIngredientAttrs.ingredientMeasure)[0].quantity;
-      const price = this.recipeIngredientAttrs.ingredient.price / defaultQuantity;
-      if (this.isInt(price)) {
-        return price;
-      }
-
-      return Math.round(this.recipeIngredientAttrs.ingredient.price / defaultQuantity);
+      return unitaryPrice(this.recipeIngredientAttrs);
     },
     price() {
-      return this.recipeIngredientAttrs.ingredientQuantity *
-      this.unitaryPrice;
+      return Math.round(this.recipeIngredientAttrs.ingredientQuantity *
+      this.unitaryPrice);
     },
     units() {
       let ingredientUnits = this.recipeIngredientAttrs

--- a/app/javascript/components/recipes/index/recipes-list/recipes-item.vue
+++ b/app/javascript/components/recipes/index/recipes-list/recipes-item.vue
@@ -15,6 +15,7 @@
 <script>
 import RecipesItemInfo from './recipes-item-info';
 import RecipesItemPrice from './recipes-item-price';
+import { getPriceOfSelectedIngredient } from '../../../../utils/recipeUtils.js';
 
 export default {
 
@@ -30,31 +31,11 @@ export default {
     ingredientFinalPrice(quantity, price) {
       return (quantity * price);
     },
-    getPriceOfSelectedIngredient(recipeIngredient) {
-      if (!recipeIngredient.ingredientQuantity) return 0;
-
-      return recipeIngredient.ingredientQuantity * this.unitaryPrice(recipeIngredient);
-    },
-
-    unitaryPrice(recipeIngredient) {
-      const defaultQuantity = recipeIngredient.ingredient.otherMeasures.data.map(element =>
-        element.attributes).filter(element =>
-        element.name === recipeIngredient.ingredientMeasure)[0].quantity;
-      const price = recipeIngredient.ingredient.price / defaultQuantity;
-      if (this.isInt(price)) {
-        return price;
-      }
-
-      return Math.round(recipeIngredient.ingredient.price / defaultQuantity);
-    },
-    isInt(n) {
-      return n % 1 === 0;
-    },
   },
   computed: {
     recipePrice() {
       return this.recipe.recipeIngredients.data.reduce((recipePrice, recipeIngredient) =>
-        recipePrice + this.getPriceOfSelectedIngredient(recipeIngredient.attributes), 0);
+        recipePrice + getPriceOfSelectedIngredient(recipeIngredient.attributes), 0);
     },
   },
 };

--- a/app/javascript/components/recipes/show/recipe-show.vue
+++ b/app/javascript/components/recipes/show/recipe-show.vue
@@ -77,6 +77,7 @@ import { getRecipe, deleteRecipe } from '../../../api/recipes.js';
 import RecipeIngredients from './recipe-ingredients';
 import RecipeInstructions from './recipe-instructions';
 import RecipeInfo from './recipe-info';
+import { getPriceOfSelectedIngredient } from '../../../utils/recipeUtils.js';
 
 export default {
   components: {
@@ -137,32 +138,12 @@ export default {
         this.loading = false;
       }
     },
-    getPriceOfSelectedIngredient(recipeIngredient) {
-      if (!recipeIngredient.ingredientQuantity) return 0;
-
-      return recipeIngredient.ingredientQuantity * this.unitaryPrice(recipeIngredient);
-    },
-
-    unitaryPrice(recipeIngredient) {
-      const defaultQuantity = recipeIngredient.ingredient.otherMeasures.data.map(element =>
-        element.attributes).filter(element =>
-        element.name === recipeIngredient.ingredientMeasure)[0].quantity;
-      const price = recipeIngredient.ingredient.price / defaultQuantity;
-      if (this.isInt(price)) {
-        return price;
-      }
-
-      return Math.round(recipeIngredient.ingredient.price / defaultQuantity);
-    },
-    isInt(n) {
-      return n % 1 === 0;
-    },
   },
 
   computed: {
     recipePrice() {
       return this.recipe.recipeIngredients.data.reduce((recipePrice, recipeIngredient) =>
-        recipePrice + this.getPriceOfSelectedIngredient(recipeIngredient.attributes), 0);
+        recipePrice + getPriceOfSelectedIngredient(recipeIngredient.attributes), 0);
     },
   },
 };

--- a/app/javascript/utils/recipeUtils.js
+++ b/app/javascript/utils/recipeUtils.js
@@ -12,12 +12,14 @@ function unitaryPrice(recipeIngredient) {
     return price;
   }
 
-  return Math.round(recipeIngredient.ingredient.price / defaultQuantity);
+  return recipeIngredient.ingredient.price / defaultQuantity;
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export function getPriceOfSelectedIngredient(recipeIngredient) {
+function getPriceOfSelectedIngredient(recipeIngredient) {
   if (!recipeIngredient.ingredientQuantity) return 0;
 
-  return recipeIngredient.ingredientQuantity * unitaryPrice(recipeIngredient);
+  return Math.round(recipeIngredient.ingredientQuantity * unitaryPrice(recipeIngredient));
 }
+
+export { unitaryPrice, getPriceOfSelectedIngredient };


### PR DESCRIPTION
# que se hizo
Se usan los metodos de recipeUtils en lugar de redefinirlos en los componentes, ademas se hizo un fix para que se mostrara el precio correctamente de una receta. (pasaba que si el precio unitario de un ingrediente era 0.3 se redondeaba a 0, y si habia 300 de esos en la receta no suponian un gasto ya que se multiplicaba 0x300 en lugar de 0.3)
# QA
Si se configura una receta para que el precio unitario de la medida a agregar sea un decimal, al aumentar la cantidad de ese ingrediente en la receta se debe actualizar su precio correctamente (En todas las vistas donde aparezca el precio de la receta)