### PR TITLE
fix(ingredients): inventory css and provider update

### DIFF
--- a/app/controllers/api/v1/ingredients_controller.rb
+++ b/app/controllers/api/v1/ingredients_controller.rb
@@ -54,13 +54,17 @@ class Api::V1::IngredientsController < Api::V1::BaseController
   end
 
   def update
-    provider = Provider.find_or_create_by(
-      name: ingredient_params[:provider_name], user: current_user
-    )
+    if ingredient_params[:provider_name].blank?
+      respond_with ingredient.update!(ingredient_params)
+    else
+      provider = Provider.find_or_create_by(
+        name: ingredient_params[:provider_name], user: current_user
+      )
 
-    respond_with ingredient.update!(
-      ingredient_params.except(:provider_name).merge(provider_id: provider.id)
-    )
+      respond_with ingredient.update!(
+        ingredient_params.except(:provider_name).merge(provider_id: provider.id)
+      )
+    end
   end
 
   def destroy

--- a/app/javascript/components/ingredients/ingredients-table.vue
+++ b/app/javascript/components/ingredients/ingredients-table.vue
@@ -30,7 +30,7 @@
     </thead>
     <tbody class="bg-gray-200">
       <tr
-        v-for="ingredient in ingredients"
+        v-for="(ingredient, idx) in ingredients"
         :key="ingredient.id"
         class="bg-white border-4 border-gray-200 text-left"
       >
@@ -69,32 +69,27 @@
         </td>
         <td class="py-2 px-8">
           <div
-            class="flex justify-between"
-            v-if="!editInventory"
+            class="flex justify-start"
           >
-            <p class="ml-2 font-medium">
-              {{ ingredient.inventory }} {{ ingredient.measure }}
-            </p>
             <img
               svg-inline
               src="../../../assets/images/pencil-svg.svg"
               class="w-4 h-4 cursor-pointer"
-              @click="toggleEditInventory"
+              @click="openEditInventory(idx)"
             >
-          </div>
-          <div
-            class="flex justify-between items-center"
-            v-else
-          >
-            <input
-              type="number"
-              min="0"
-              ref="inventory"
-              class="w-10 border-2 border-solid border-gray-400 box-border"
-              v-model="ingredient.inventory"
-              @blur.prevent="changeInventory(ingredient, ingredient.inventory)"
-            >
-            {{ ingredient.measure }}
+            <div class="flex">
+              <input
+                type="number"
+                min="0"
+                ref="inventory"
+                class="w-12 m-auto font-medium border-none outline-none text-center"
+                v-model="ingredient.inventory"
+                @blur.prevent="changeInventory(ingredient, ingredient.inventory)"
+              >
+              <div class="flex m-auto font-medium">
+                {{ ingredient.measure }}
+              </div>
+            </div>
           </div>
         </td>
         <td class="content-center">
@@ -119,12 +114,6 @@ export default {
   components: {
     IngredientsTableUnitPrice,
   },
-  data() {
-    return {
-      editInventory: false,
-    };
-  },
-
   props: {
     ingredients: { type: Array, required: true },
   },
@@ -135,12 +124,13 @@ export default {
     deleteIngredient(element) {
       this.$emit('del', element);
     },
-    toggleEditInventory() {
-      this.editInventory = !this.editInventory;
+    openEditInventory(idx) {
+      this.$nextTick(() => {
+        this.$refs.inventory[idx].focus();
+      });
     },
     changeInventory(ingredient, inventory) {
       ingredient.inventory = inventory;
-      this.editInventory = !this.editInventory;
       this.$emit('updateInventory', ingredient);
     },
   },

--- a/app/javascript/components/menus/index/menu-shopping-list.vue
+++ b/app/javascript/components/menus/index/menu-shopping-list.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex w-full m-auto">
+  <div>
     <button
       class="focus:outline-none"
       @click="toggleList"

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -97,17 +97,18 @@
           class="content-center py-2 px-8 items-center"
         >
           <div class="flex flex-col">
-            <div class="flex justify-between w-full">
+            <div class="flex w-full justify-between">
               <menu-shopping-list
+                class="flex w-5/12 m-auto"
                 :menu-id="menu.id"
                 @reduceInventory="toggleReduce"
               />
-              <p>
+              <div class="flex w-7/12">
                 Lista de Compras
-              </p>
+              </div>
             </div>
             <div class="flex w-full justify-between">
-              <div class="flex w-full m-auto">
+              <div class="flex w-5/12 m-auto">
                 <img
                   svg-inline
                   src="../../../../assets/images/reduce-inventory-svg.svg"
@@ -115,9 +116,9 @@
                   @click="toggleReduce(menu.id)"
                 >
               </div>
-              <p>
+              <div class="flex w-7/12">
                 Restar Inventario
-              </p>
+              </div>
             </div>
           </div>
         </td>

--- a/app/javascript/components/providers/index/provider-item.vue
+++ b/app/javascript/components/providers/index/provider-item.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="flex flex-col m-auto p-4 border-2 border-solid border-gray-400 box-border flex-none mb-6 w-96 order-none">
-    <div class="flex flex-row items-center w-auto h-auto flex-none self-stretch my-4 px-3">
+  <div class="flex flex-col m-auto p-4 border-2 border-solid border-gray-400 box-border mb-6 w-96 order-none">
+    <div class="flex flex-row items-center w-auto h-auto self-stretch my-4 px-3">
       <!-- Imagen -->
-      <div class="w-24 h-24 border-2 border-solid border-gray-400 box-border flex-none mr-2 order-none">
+      <div class="w-24 h-24 border-2 border-solid border-gray-400 box-border mr-2 order-none">
         <img
           svg-inline
           src="../../../../assets/images/recipe.jpg"
@@ -10,16 +10,16 @@
         >
       </div>
       <!-- Info -->
-      <div class="flex flex-col w-auto h-auto flex-none self-stretch flex-grow mr-2">
+      <div class="flex flex-col w-auto h-auto self-stretch flex-grow mx-2">
         <!-- nombre Proveedor -->
-        <div class="flex items-center w-auto h-5 flex-none">
+        <div class="flex items-center w-auto h-5">
           {{ provider.name }}
         </div>
-        <div class="flex flex-col items-start w-auto h-10 flex-none my-4">
+        <div class="flex flex-col items-start w-auto h-10 my-4">
           <!-- Mail -->
-          <div class="flex items-center w-auto h-5 flex-none mb-4">
+          <div class="flex items-center w-auto h-5 mb-4">
             <!-- Icono -->
-            <div class="w-4 h-4 flex-none m-1.5">
+            <div class="w-4 h-4 mr-1.5">
               <img
                 svg-inline
                 src="../../../../assets/images/mail-svg.svg"
@@ -27,14 +27,14 @@
               >
             </div>
             <!-- Texto -->
-            <div class="flex w-auto h-5 text-base items-center text-gray-400 flex-none">
+            <div class="flex w-auto h-5 text-base items-center text-gray-400">
               {{ provider.email }}
             </div>
           </div>
           <!-- Telefono -->
-          <div class="flex items-center w-auto h-5 flex-none">
+          <div class="flex items-center w-auto h-5">
             <!-- Icono -->
-            <div class="w-4 h-4 flex-none m-1.5">
+            <div class="w-4 h-4 mr-1.5">
               <img
                 svg-inline
                 src="../../../../assets/images/phone-svg.svg"
@@ -42,7 +42,7 @@
               >
             </div>
             <!-- Texto -->
-            <div class="flex w-auto h-5 text-base items-center text-gray-400 flex-none">
+            <div class="flex w-auto h-5 text-base items-center text-gray-400">
               {{ provider.phone }}
             </div>
           </div>
@@ -50,7 +50,7 @@
       </div>
       <!-- flecha -->
       <div
-        class="flex items-center w-6 h-6 flex-none self-stretch justify-self-end"
+        class="flex items-center w-6 h-6 self-stretch justify-self-end"
         @click="toggleOpenModal"
       >
         <img
@@ -63,12 +63,12 @@
     <div
       v-if="showingDetails"
     >
-      <div class="flex flex-col items-start flex-none order-1 w-80 mr-1">
+      <div class="flex flex-col items-start order-1 w-80 mr-1">
         <!-- Pagina Web -->
-        <div class="flex flex-row items-start flex-none order-none w-full justify-between">
-          <div class="flex flex-row flex-none items-center order-none w-48">
+        <div class="flex flex-row items-start order-none w-full justify-between">
+          <div class="flex flex-row items-center order-none w-48">
             <!-- Icono -->
-            <div class="w-4 h-4 flex-none m-1.5">
+            <div class="w-4 h-4 m-1.5">
               <img
                 svg-inline
                 src="../../../../assets/images/webpage-svg.svg"
@@ -89,10 +89,10 @@
           </div>
         </div>
         <!-- Datos bancarios -->
-        <div class="flex flex-row items-start flex-none order-none w-full justify-between">
-          <div class="flex flex-row flex-none items-center order-none w-48">
+        <div class="flex flex-row items-start order-none w-full justify-between">
+          <div class="flex flex-row items-center order-none w-48">
             <!-- Icono -->
-            <div class="w-4 h-4 flex-none m-1.5">
+            <div class="w-4 h-4 m-1.5">
               <img
                 svg-inline
                 src="../../../../assets/images/credit-card-svg.svg"
@@ -113,10 +113,10 @@
           </button>
         </div>
         <!-- Minimo Compra -->
-        <div class="flex flex-row items-start flex-none order-none w-full justify-between">
-          <div class="flex flex-row flex-none items-center order-none w-48">
+        <div class="flex flex-row items-start order-none w-full justify-between">
+          <div class="flex flex-row items-center order-none w-48">
             <!-- Icono -->
-            <div class="w-4 h-4 flex-none m-1.5">
+            <div class="w-4 h-4 m-1.5">
               <img
                 svg-inline
                 src="../../../../assets/images/dolar-svg.svg"
@@ -129,15 +129,15 @@
             </p>
           </div>
           <!-- Minimo -->
-          <p class="flex items-center text-black flex-none order-1 flex-grow-0 text-right justify-items-end">
+          <p class="flex items-center text-black order-1 flex-grow-0 text-right justify-items-end">
             $ {{ provider.minimumPurchase }}
           </p>
         </div>
         <!-- Tiempo de Despacho -->
-        <div class="flex flex-row items-start flex-none order-none w-full justify-between mb-2">
-          <div class="flex flex-row flex-none items-center order-none w-48">
+        <div class="flex flex-row items-start order-none w-full justify-between mb-2">
+          <div class="flex flex-row items-center order-none w-48">
             <!-- Icono -->
-            <div class="w-4 h-4 flex-none m-1.5">
+            <div class="w-4 h-4 m-1.5">
               <img
                 svg-inline
                 src="../../../../assets/images/car-svg.svg"
@@ -150,16 +150,16 @@
             </p>
           </div>
           <!-- Tiempo -->
-          <p class="flex items-center text-black flex-none order-1 text-right justify-items-end">
+          <p class="flex items-center text-black order-1 text-right justify-items-end">
             {{ provider.deliveryDays }} {{ $t('msg.providers.days') }}
           </p>
         </div>
       </div>
       <!-- botones -->
-      <div class="flex flex-row items-start flex-none order-2 self-stretch w-80 justify-between mx-2">
+      <div class="flex flex-row items-start order-2 self-stretch w-80 justify-between mx-2">
         <div>
           <button
-            class="flex flex-row items-center justify-center bg-green-500 hover:bg-green-700 text-white rounded flex-none order-1 flex-grow-1 px-2"
+            class="flex flex-row items-center justify-center bg-green-500 hover:bg-green-700 text-white rounded order-1 flex-grow-1 px-2"
             @click="toggleDelModal"
           >
             {{ $t('msg.providers.delete') }}
@@ -167,7 +167,7 @@
         </div>
         <div>
           <button
-            class="flex flex-row items-center justify-center bg-white hover:bg-gray-300 text-black rounded flex-none order-1 flex-grow-1 px-2"
+            class="flex flex-row items-center justify-center bg-white hover:bg-gray-300 text-black rounded order-1 flex-grow-1 px-2"
             @click="toggleEditModal"
           >
             {{ $t('msg.providers.edit') }}

--- a/spec/integration/api/v1/ingredients_spec.rb
+++ b/spec/integration/api/v1/ingredients_spec.rb
@@ -338,7 +338,8 @@ describe 'API::V1::Ingredients', swagger_doc: 'v1/swagger.json' do
 
     parameter name: :id, in: :path, type: :integer
 
-    let(:existent_ingredient) { create(:ingredient, user_id: user.id) }
+    let!(:provider) { create(:provider, user: user) }
+    let(:existent_ingredient) { create(:ingredient, user_id: user.id, provider: provider) }
     let(:id) { existent_ingredient.id }
 
     get 'Retrieves Ingredient' do
@@ -392,7 +393,9 @@ describe 'API::V1::Ingredients', swagger_doc: 'v1/swagger.json' do
           }
         end
 
-        run_test!
+        run_test! do
+          expect(existent_ingredient.reload.provider).to eq(provider)
+        end
       end
 
       response '200', 'ingredient updated with measure by default' do


### PR DESCRIPTION
Dos cosas:

Cuando alguien mandaba un update sin proveedor, por construcción se asignaba un proveedor nulo. Pero debería ocurrir únicamente en el create

Arreglé harto CSS:
- vista de proveedores; alineo nombre del proveedor + datos
- vista de menús: alineo correctamente el ícono + descripciones de shopping list y reducir inventario
- vista de ingredientes; ahora se puede editar inline los inventarios y se actualizarán de una. si hace click en el lapicito o en el número se hará focus en el input (que siempre existe)

https://user-images.githubusercontent.com/30879716/124042371-b18d7a80-d9d6-11eb-8253-9d70fbae1fd6.mov

