### PR TITLE
fix(minimum-inventory): display 0 on border cases

### DIFF
--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -340,19 +340,9 @@ export default {
     },
 
     // eslint-disable-next-line max-statements
-    async editIngredient() { // eslint-disable-line complexity
+    async editIngredient() {
       const ingredientsInfo = this.$refs.editIngredientInfo.form;
-      if (!ingredientsInfo.name || !ingredientsInfo.ingredientMeasuresAttributes[0].quantity ||
-      !ingredientsInfo.ingredientMeasuresAttributes[0].name) {
-        // eslint-disable-next-line no-alert
-        alert(this.$t('msg.ingredients.msjAlert'));
-
-        return;
-      } else if (ingredientsInfo.ingredientMeasuresAttributes[0].quantity < 1 ||
-      ingredientsInfo.minimumQuantity < 0) {
-        // eslint-disable-next-line no-alert
-        alert(this.$t('msg.ingredients.msjMinQuantity'));
-
+      if (this.checkErrorsEditIngredient(ingredientsInfo)) {
         return;
       }
       if (this.validations(this.$refs.editIngredientInfo.form)) {
@@ -372,7 +362,27 @@ export default {
         }
       }
     },
+    checkErrorsEditIngredient(info) {
+      if (!info.name || !info.ingredientMeasuresAttributes[0].quantity ||
+      !info.ingredientMeasuresAttributes[0].name) {
+        // eslint-disable-next-line no-alert
+        alert(this.$t('msg.ingredients.msjAlert'));
 
+        return true;
+      } else if (info.ingredientMeasuresAttributes[0].quantity < 1) {
+        // eslint-disable-next-line no-alert
+        alert(this.$t('msg.ingredients.msjMinQuantity'));
+
+        return true;
+      } else if (info.minimumQuantity < 0) {
+        // eslint-disable-next-line no-alert
+        alert(this.$t('msg.ingredients.msjNegativeQuantity'));
+
+        return true;
+      }
+
+      return false;
+    },
     addMeasuresToDelete(ingredientsInfo) {
       this.$refs.editIngredientInfo.measuresToDelete
         .forEach(elem => ingredientsInfo.ingredientMeasuresAttributes.push({ id: elem, _destroy: true }));

--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -340,8 +340,21 @@ export default {
     },
 
     // eslint-disable-next-line max-statements
-    async editIngredient() {
+    async editIngredient() { // eslint-disable-line complexity
       const ingredientsInfo = this.$refs.editIngredientInfo.form;
+      if (!ingredientsInfo.name || !ingredientsInfo.ingredientMeasuresAttributes[0].quantity ||
+      !ingredientsInfo.ingredientMeasuresAttributes[0].name) {
+        // eslint-disable-next-line no-alert
+        alert(this.$t('msg.ingredients.msjAlert'));
+
+        return;
+      } else if (ingredientsInfo.ingredientMeasuresAttributes[0].quantity < 1 ||
+      ingredientsInfo.minimumQuantity < 0) {
+        // eslint-disable-next-line no-alert
+        alert(this.$t('msg.ingredients.msjMinQuantity'));
+
+        return;
+      }
       if (this.validations(this.$refs.editIngredientInfo.form)) {
         try {
           this.showingEdit = !this.showingEdit;

--- a/app/javascript/components/ingredients/ingredients-table.vue
+++ b/app/javascript/components/ingredients/ingredients-table.vue
@@ -99,14 +99,22 @@
           <!-- minimum quantity -->
           <td class="py-2">
             <p
+              class="ml-2 font-medium"
+              v-if="ingredient.minimumQuantity == ''"
+            >
+              0
+            </p>
+            <p
+              class="ml-2 font-medium"
               v-if="ingredient.minimumQuantity != undefined"
             >
               {{ ingredient.minimumQuantity }}
             </p>
             <p
+              class="ml-2 font-medium"
               v-if="ingredient.minimumQuantity == undefined"
             >
-              -
+              0
             </p>
           </td>
           <td class="content-center">

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -75,6 +75,9 @@ export default {
       defaultUnit: 'Unidad por defecto',
       alternativeUnit: 'Unidades alternativas',
       addUnit: 'Agregar Unidad',
+      msjAlert: 'Debe ingresar el nombre, la cantidad y la unidad',
+      msjMinQuantity: 'El inventario debe ser mayor o igual a 1',
+      msjNegativeQuantity: 'La cantidad mínima debe ser mayor o igual a 0',
       associationWarning: 'Este ingrediente se encuentra en la(s) siguiente(s) receta(s):',
       newMeasure: 'Crear la medida',
       inventory: {


### PR DESCRIPTION
# Contexto
Cuando un ingrediente tiene una cantidad mínima de ingredientes, se mostraba un guión `-` o nada, lo que no era representativo, sino que poner un `0` deja claro la cantidad mínima de ingredientes. También, se aceptaban cantidades mínimas menores que 0.

# QA
Entrar a `/ingredients`, editar o crear un ingrediente y ponerle cualquier numero o dejarlo vacío. Si el número es menor que 0, debe aparecer una alerta y no dejar que se guarde es valor. Si es cualquier otro número, debe guardarse. Si no se ingresa nada, debe guardarse por defecto el valor 0.