### PR TITLE
Fix ingredients table

### DIFF
--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -34,10 +34,11 @@
             </div>
           </div>
           <div class="flex justify-start px-2 pb-2 my-auto">
-            <a
-              class="font-bold py-2 px-6 rounded shadow-md w-full h-auto focus:outline-none bg-green-500 hover:bg-green-700 text-white"
-              href="/ingredients/show"
-            >{{ $t('msg.ingredients.inventory.editInventories') }}</a>
+            <base-button
+              :elements="{ placeholder: $t('msg.ingredients.inventory.editInventories'),
+                           color: 'bg-green-500 hover:bg-green-700 text-white' }"
+              @click="goToEditInventories"
+            />
           </div>
           <div class="flex justify-start px-2 pb-2 my-auto">
             <base-button
@@ -247,6 +248,9 @@ export default {
       if (this.showingDel) {
         this.getIngredientAssociations(ingredient.id);
       }
+    },
+    goToEditInventories() {
+      window.location = '/ingredients/show';
     },
 
     async getIngredientAssociations(ingredientId) {

--- a/app/javascript/components/ingredients/ingredients-table.vue
+++ b/app/javascript/components/ingredients/ingredients-table.vue
@@ -1,128 +1,130 @@
 <template>
-  <table
-    class="divide-y divide-gray-200 w-full"
-  >
-    <thead class="justify-between bg-gray-600 border-4 border-gray-600">
-      <tr class="text-left items-center w-full">
-        <th class="px-8 py-3">
-          <span class="text-white font-bold">{{ $t('msg.ingredients.name') }}</span>
-        </th>
-        <th class="px-8 py-3">
-          <span class="text-white font-bold">{{ $t('msg.ingredients.provider') }}</span>
-        </th>
-        <th class="px-8 py-3">
-          <span class="text-white font-bold">{{ $t('msg.ingredients.price') }}($)</span>
-        </th>
-        <th class="px-8 py-3">
-          <span class="text-white font-bold">{{ $t('msg.ingredients.quantity') }}</span>
-        </th>
-        <th class="px-8 py-3">
-          <span class="text-white font-bold">{{ $t('msg.ingredients.measure') }}</span>
-        </th>
-        <th class="px-8 py-3">
-          <span class="text-white font-bold">{{ $t('msg.ingredients.unitPrice') }}($)</span>
-        </th>
-        <th class="px-8 py-3">
-          <span class="text-white font-bold">{{ $t('msg.ingredients.inventory.title') }}</span>
-        </th>
-        <th class="px-8 py-3">
-          <span class="text-white font-bold">{{ $t('msg.ingredients.minimumQuantityShort') }}</span>
-        </th>
-        <th class="px-8 py-3" />
-      </tr>
-    </thead>
-    <tbody class="bg-gray-200">
-      <tr
-        v-for="(ingredient, idx) in ingredients"
-        :key="ingredient.id"
-        class="bg-white border-4 border-gray-200 text-left"
-      >
-        <!-- ingredient name -->
-        <td class="py-2 px-8">
-          <p class="ml-2 font-medium">
-            {{ ingredient.name }}
-          </p>
-        </td>
-        <td class="py-2 px-8">
-          <p class="ml-2 font-medium">
-            {{ ingredient.providerName === null ? "-" : ingredient.providerName }}
-          </p>
-        </td>
-        <!-- price -->
-        <td class="py-2 px-8">
-          <p class="ml-2 font-medium">
-            {{ ingredient.price | currency }}
-          </p>
-        </td>
-        <!-- quantity -->
-        <td class="py-2 px-8">
-          <p class="ml-2 font-medium">
-            {{ ingredient.quantity }}
-          </p>
-        </td>
-        <td class="py-2 px-8">
-          <p class="ml-2 font-medium">
-            {{ ingredient.measure }}
-          </p>
-        </td>
-        <td class="py-2 px-8">
-          <ingredients-table-unit-price
-            :ingredient="ingredient"
-          />
-        </td>
-        <td class="py-2 px-8">
-          <div
-            class="flex justify-start"
-          >
-            <img
-              svg-inline
-              src="../../../assets/images/pencil-svg.svg"
-              class="w-4 h-4 cursor-pointer"
-              @click="openEditInventory(idx)"
+  <div class="w-full">
+    <table
+      class="divide-y divide-gray-200 w-full"
+    >
+      <thead class="justify-between bg-gray-600 border-4 border-gray-600">
+        <tr class="text-left items-center w-full">
+          <th class="px-8 py-3">
+            <span class="text-white font-bold">{{ $t('msg.ingredients.name') }}</span>
+          </th>
+          <th class="px-8 py-3">
+            <span class="text-white font-bold">{{ $t('msg.ingredients.provider') }}</span>
+          </th>
+          <th class="px-8 py-3">
+            <span class="text-white font-bold">{{ $t('msg.ingredients.price') }}($)</span>
+          </th>
+          <th class="px-8 py-3">
+            <span class="text-white font-bold">{{ $t('msg.ingredients.quantity') }}</span>
+          </th>
+          <th class="px-8 py-3">
+            <span class="text-white font-bold">{{ $t('msg.ingredients.measure') }}</span>
+          </th>
+          <th class="px-8 py-3">
+            <span class="text-white font-bold">{{ $t('msg.ingredients.unitPrice') }}($)</span>
+          </th>
+          <th class="px-8 py-3">
+            <span class="text-white font-bold">{{ $t('msg.ingredients.inventory.title') }}</span>
+          </th>
+          <th class="px-8 py-3">
+            <span class="text-white font-bold">{{ $t('msg.ingredients.minimumQuantityShort') }}</span>
+          </th>
+          <th class="px-8 py-3" />
+        </tr>
+      </thead>
+      <tbody class="bg-gray-200">
+        <tr
+          v-for="(ingredient, idx) in ingredients"
+          :key="ingredient.id"
+          class="bg-white border-4 border-gray-200 text-left"
+        >
+          <!-- ingredient name -->
+          <td class="py-2 px-8">
+            <p class="ml-2 font-medium">
+              {{ ingredient.name }}
+            </p>
+          </td>
+          <td class="py-2 px-8">
+            <p class="ml-2 font-medium">
+              {{ ingredient.providerName === null ? "-" : ingredient.providerName }}
+            </p>
+          </td>
+          <!-- price -->
+          <td class="py-2 px-8">
+            <p class="ml-2 font-medium">
+              {{ ingredient.price | currency }}
+            </p>
+          </td>
+          <!-- quantity -->
+          <td class="py-2 px-8">
+            <p class="ml-2 font-medium">
+              {{ ingredient.quantity }}
+            </p>
+          </td>
+          <td class="py-2 px-8">
+            <p class="ml-2 font-medium">
+              {{ ingredient.measure }}
+            </p>
+          </td>
+          <td class="py-2 px-8">
+            <ingredients-table-unit-price
+              :ingredient="ingredient"
+            />
+          </td>
+          <td class="py-2 px-8">
+            <div
+              class="flex justify-start"
             >
-            <div class="flex">
-              <input
-                type="number"
-                min="0"
-                ref="inventory"
-                class="w-12 m-auto font-medium border-none outline-none text-center"
-                v-model="ingredient.inventory"
-                @blur.prevent="changeInventory(ingredient, ingredient.inventory)"
+              <img
+                svg-inline
+                src="../../../assets/images/pencil-svg.svg"
+                class="w-4 h-4 cursor-pointer"
+                @click="openEditInventory(idx)"
               >
-              <div class="flex m-auto font-medium">
-                {{ ingredient.measure }}
+              <div class="flex">
+                <input
+                  type="number"
+                  min="0"
+                  ref="inventory"
+                  class="w-12 m-auto font-medium border-none outline-none text-center"
+                  v-model="ingredient.inventory"
+                  @blur.prevent="changeInventory(ingredient, ingredient.inventory)"
+                >
+                <div class="flex m-auto font-medium">
+                  {{ ingredient.measure }}
+                </div>
               </div>
             </div>
-          </div>
-        </td>
-        <!-- minimum quantity -->
-        <td class="py-2 px-8">
-          <p
-            class="ml-2 font-medium"
-            v-if="ingredient.minimumQuantity != undefined"
-          >
-            {{ ingredient.minimumQuantity }}
-          </p>
-          <p
-            class="ml-2 font-medium"
-            v-if="ingredient.minimumQuantity == undefined"
-          >
-            -
-          </p>
-        </td>
-        <td class="content-center">
-          <dots-dropdown
-            :elements="{
-              edit:true,
-              del:true
-            }"
-            @edit="editIngredient(ingredient)"
-            @delete="deleteIngredient(ingredient)"
-          />
-        </td>
-      </tr>
-    </tbody>
-  </table>
+          </td>
+          <!-- minimum quantity -->
+          <td class="py-2 px-8">
+            <p
+              class="ml-2 font-medium"
+              v-if="ingredient.minimumQuantity != undefined"
+            >
+              {{ ingredient.minimumQuantity }}
+            </p>
+            <p
+              class="ml-2 font-medium"
+              v-if="ingredient.minimumQuantity == undefined"
+            >
+              -
+            </p>
+          </td>
+          <td class="content-center">
+            <dots-dropdown
+              :elements="{
+                edit:true,
+                del:true
+              }"
+              @edit="editIngredient(ingredient)"
+              @delete="deleteIngredient(ingredient)"
+            />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </template>
 
 <script>

--- a/app/javascript/components/menus/index/menus-container.vue
+++ b/app/javascript/components/menus/index/menus-container.vue
@@ -47,11 +47,14 @@
         >
           {{ $t('msg.noElements') }} {{ $t('msg.menus.title').toLowerCase() }}
         </p>
-        <div v-else class="flex w-full 2xl:justify-center items-center overflow-auto">
+        <div
+          v-else
+          class="flex w-full 2xl:justify-center items-center overflow-auto"
+        >
           <menus-table
-          :menus="filterMenus"
-          @del="toggleDelModal"
-        />
+            :menus="filterMenus"
+            @del="toggleDelModal"
+          />
         </div>
       </div>
     </div>

--- a/app/javascript/components/menus/index/menus-container.vue
+++ b/app/javascript/components/menus/index/menus-container.vue
@@ -47,11 +47,12 @@
         >
           {{ $t('msg.noElements') }} {{ $t('msg.menus.title').toLowerCase() }}
         </p>
-        <menus-table
-          v-else
+        <div v-else class="flex w-full 2xl:justify-center items-center overflow-auto">
+          <menus-table
           :menus="filterMenus"
           @del="toggleDelModal"
         />
+        </div>
       </div>
     </div>
 

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -1,152 +1,154 @@
 <template>
-  <table class="w-full divide-y divide-gray-200">
-    <thead class="justify-between bg-gray-600 border-4 border-gray-600">
-      <tr class="text-left">
-        <th
-          class="px-8 py-3"
+  <div class="w-full">
+    <table class="w-full divide-y divide-gray-200">
+      <thead class="justify-between bg-gray-600 border-4 border-gray-600">
+        <tr class="text-left">
+          <th
+            class="px-8 py-3"
+          >
+            <span class="text-white font-bold">{{ $t('msg.menus.name') }}</span>
+          </th>
+          <th
+            class="px-8 py-3"
+          >
+            <span class="text-white font-bold">{{ $t('msg.menus.totalCost') }}</span>
+          </th>
+          <th
+            class="px-8 py-3"
+          >
+            <span class="text-white font-bold">{{ $t('msg.menus.portions') }}</span>
+          </th>
+          <th
+            class="px-8 py-3"
+          >
+            <span class="text-white font-bold">{{ $t('msg.menus.recipesQuantity') }}</span>
+          </th>
+          <th
+            class="px-8 py-3"
+          >
+            <span class="text-white font-bold">{{ $t('msg.menus.recipes') }}</span>
+          </th>
+          <th
+            class="px-8 py-3"
+          >
+            <span class="text-white font-bold">{{ $t('msg.menus.actions') }}</span>
+          </th>
+          <th
+            class="px-8 py-3"
+          />
+        </tr>
+      </thead>
+      <tbody class="bg-gray-200">
+        <tr
+          v-for="menu in menus"
+          :key="menu.id"
+          class="bg-white border-4 border-gray-200 text-left"
         >
-          <span class="text-white font-bold">{{ $t('msg.menus.name') }}</span>
-        </th>
-        <th
-          class="px-8 py-3"
-        >
-          <span class="text-white font-bold">{{ $t('msg.menus.totalCost') }}</span>
-        </th>
-        <th
-          class="px-8 py-3"
-        >
-          <span class="text-white font-bold">{{ $t('msg.menus.portions') }}</span>
-        </th>
-        <th
-          class="px-8 py-3"
-        >
-          <span class="text-white font-bold">{{ $t('msg.menus.recipesQuantity') }}</span>
-        </th>
-        <th
-          class="px-8 py-3"
-        >
-          <span class="text-white font-bold">{{ $t('msg.menus.recipes') }}</span>
-        </th>
-        <th
-          class="px-8 py-3"
-        >
-          <span class="text-white font-bold">{{ $t('msg.menus.actions') }}</span>
-        </th>
-        <th
-          class="px-8 py-3"
-        />
-      </tr>
-    </thead>
-    <tbody class="bg-gray-200">
-      <tr
-        v-for="menu in menus"
-        :key="menu.id"
-        class="bg-white border-4 border-gray-200 text-left"
+          <!-- name -->
+          <td
+            key="name"
+            class="py-2 px-8"
+          >
+            <p
+              class="ml-2 font-medium"
+            >
+              {{ menu.name }}
+            </p>
+          </td>
+          <!-- totalPrice -->
+          <td
+            key="totalPrice"
+            class="py-2 px-8"
+          >
+            <p
+              class="ml-2 font-medium"
+            >
+              {{ totalMenuPrice(menu.menuRecipes.data) | currency }}
+            </p>
+          </td>
+          <td
+            key="portions"
+            class="py-2 px-8"
+          >
+            <p
+              class="ml-2 font-medium"
+            >
+              {{ menu.portions }}
+            </p>
+          </td>
+          <!-- recipesQuantity -->
+          <td
+            key="recipesQuantity"
+            class="py-2 px-8"
+          >
+            <menus-table-recipes-quantity
+              :menu="menu"
+            />
+          </td>
+          <!-- recipes -->
+          <td
+            key="recipes"
+            class="py-2 px-4"
+          >
+            <menus-table-recipes
+              :menu="menu"
+            />
+          </td>
+          <td
+            class="content-center py-2 px-8 items-center"
+          >
+            <div class="flex flex-col">
+              <div class="flex w-full justify-between">
+                <menu-shopping-list
+                  class="flex w-5/12 m-auto"
+                  :menu-id="menu.id"
+                  @reduceInventory="toggleReduce"
+                />
+                <div class="flex w-7/12">
+                  Lista de Compras
+                </div>
+              </div>
+              <div class="flex w-full justify-between">
+                <div class="flex w-5/12 m-auto">
+                  <img
+                    svg-inline
+                    src="../../../../assets/images/reduce-inventory-svg.svg"
+                    class="w-6 h-6 cursor-pointer"
+                    @click="toggleReduce(menu.id)"
+                  >
+                </div>
+                <div class="flex w-7/12">
+                  Restar Inventario
+                </div>
+              </div>
+            </div>
+          </td>
+          <td
+            class="content-center"
+          >
+            <dots-dropdown
+              :elements="{
+                edit:true,
+                del:true
+              }"
+              @edit="editMenu(menu)"
+              @delete="deleteMenu(menu)"
+            />
+          </td>
+        </tr>
+      </tbody>
+      <base-modal
+        @ok="reduceInventory"
+        @cancel="toggleReduce"
+        v-if="showingReduceMsg"
+        :title="$t('msg.menus.reduceInventory')"
+        :ok-button-label="$t('msg.menus.yesReduce')"
+        :cancel-button-label="$t('msg.cancel')"
       >
-        <!-- name -->
-        <td
-          key="name"
-          class="py-2 px-8"
-        >
-          <p
-            class="ml-2 font-medium"
-          >
-            {{ menu.name }}
-          </p>
-        </td>
-        <!-- totalPrice -->
-        <td
-          key="totalPrice"
-          class="py-2 px-8"
-        >
-          <p
-            class="ml-2 font-medium"
-          >
-            {{ totalMenuPrice(menu.menuRecipes.data) | currency }}
-          </p>
-        </td>
-        <td
-          key="portions"
-          class="py-2 px-8"
-        >
-          <p
-            class="ml-2 font-medium"
-          >
-            {{ menu.portions }}
-          </p>
-        </td>
-        <!-- recipesQuantity -->
-        <td
-          key="recipesQuantity"
-          class="py-2 px-8"
-        >
-          <menus-table-recipes-quantity
-            :menu="menu"
-          />
-        </td>
-        <!-- recipes -->
-        <td
-          key="recipes"
-          class="py-2 px-4"
-        >
-          <menus-table-recipes
-            :menu="menu"
-          />
-        </td>
-        <td
-          class="content-center py-2 px-8 items-center"
-        >
-          <div class="flex flex-col">
-            <div class="flex w-full justify-between">
-              <menu-shopping-list
-                class="flex w-5/12 m-auto"
-                :menu-id="menu.id"
-                @reduceInventory="toggleReduce"
-              />
-              <div class="flex w-7/12">
-                Lista de Compras
-              </div>
-            </div>
-            <div class="flex w-full justify-between">
-              <div class="flex w-5/12 m-auto">
-                <img
-                  svg-inline
-                  src="../../../../assets/images/reduce-inventory-svg.svg"
-                  class="w-6 h-6 cursor-pointer"
-                  @click="toggleReduce(menu.id)"
-                >
-              </div>
-              <div class="flex w-7/12">
-                Restar Inventario
-              </div>
-            </div>
-          </div>
-        </td>
-        <td
-          class="content-center"
-        >
-          <dots-dropdown
-            :elements="{
-              edit:true,
-              del:true
-            }"
-            @edit="editMenu(menu)"
-            @delete="deleteMenu(menu)"
-          />
-        </td>
-      </tr>
-    </tbody>
-    <base-modal
-      @ok="reduceInventory"
-      @cancel="toggleReduce"
-      v-if="showingReduceMsg"
-      :title="$t('msg.menus.reduceInventory')"
-      :ok-button-label="$t('msg.menus.yesReduce')"
-      :cancel-button-label="$t('msg.cancel')"
-    >
-      <p>{{ $t('msg.menus.reduceMsg') }}</p>
-    </base-modal>
-  </table>
+        <p>{{ $t('msg.menus.reduceMsg') }}</p>
+      </base-modal>
+    </table>
+  </div>
 </template>
 
 <script>

--- a/app/javascript/components/providers/index/providers-form.vue
+++ b/app/javascript/components/providers/index/providers-form.vue
@@ -10,7 +10,7 @@
     >
       <div class="pt-3">
         <form class="w-full max-w-lg">
-          <div class="flex flex-wrap -mx-3 mb-6">
+          <div class="flex flex-wrap -mx-3 mb-3">
             <div class="w-full px-3">
               <!--Name -->
               <label
@@ -28,8 +28,7 @@
               >
             </div>
           </div>
-
-          <div class="flex flex-wrap -mx-3 mb-6">
+          <div class="flex flex-wrap -mx-3 mb-3">
             <div class="w-full md:w-1/2 px-3 mb-6 md:mb-0">
               <!--Correo -->
               <label
@@ -47,7 +46,7 @@
               >
               <!--Phone -->
             </div>
-            <div class="relative">
+            <div class="w-full md:w-1/2 px-3 mb-6 md:mb-0">
               <label
                 class="block text-gray-700 text-sm font-bold mb-2"
                 for="provider-phone"
@@ -64,7 +63,7 @@
             </div>
           </div>
 
-          <div class="flex flex-wrap -mx-3 mb-6">
+          <div class="flex flex-wrap -mx-3 mb-3">
             <div class="w-full md:w-1/2 px-3 mb-6 md:mb-0">
               <!--WebpageUrl -->
               <label
@@ -81,7 +80,7 @@
                 v-model="form.webpageUrl"
               >
             </div>
-            <div class="relative">
+            <div class="w-full md:w-1/2 px-3 mb-6 md:mb-0">
               <!--DeliberyDays -->
               <label
                 class="block text-gray-700 text-sm font-bold mb-2"
@@ -117,7 +116,7 @@
             </div>
           </div>
           <!-- Datos bancarios -->
-          <div class="flex flex-wrap -mx-3 mb-6">
+          <div class="flex flex-wrap -mx-3">
             <div class="w-full px-3">
               <label
                 class="block text-gray-700 text-sm font-bold mb-2"

--- a/app/javascript/components/recipes/index/filters.vue
+++ b/app/javascript/components/recipes/index/filters.vue
@@ -26,7 +26,7 @@
         <img
           svg-inline
           src="../../../../assets/images/cross-svg.svg"
-          class="h-4 w-4 inline-block ml-3"
+          class="h-4 w-4 inline-block ml-3 cursor-pointer"
           @click="toggleDeletePrice"
         >
       </div>
@@ -42,7 +42,7 @@
         <img
           svg-inline
           src="../../../../assets/images/cross-svg.svg"
-          class="h-4 w-4 inline-block ml-3"
+          class="h-4 w-4 inline-block ml-3 cursor-pointer"
           @click="toggleDeletePortions"
         >
       </div>

--- a/app/javascript/components/recipes/index/recipes-list/recipes-item-info.vue
+++ b/app/javascript/components/recipes/index/recipes-list/recipes-item-info.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col items-start p-0 static w-64 h-14">
+  <div class="flex flex-col items-start p-0 static w-auto h-14">
     <div class="flex-none order-0 flex-grow-0 mx-2.5">
       <div class="static w-auto h-6 font-sans not-italic font-normal text-lg text-black">
         <div class="flex-none order-0 flex-grow-0 mx-0">
@@ -7,9 +7,9 @@
         </div>
       </div>
 
-      <div class="items-start p-0 static w-64 h-5 left-0">
+      <div class="items-start p-0 static w-auto h-5 left-0">
         <div class=" flex flex-row order-1 flex-grow-0 my-2.5 mx-0">
-          <div class="flex flex-row items-center p-0 w-40 h-5 top-0 left-0 flex-none order-0 flex-grow-0 my-0">
+          <div class="flex flex-row items-center p-0 w-auto h-5 top-0 left-0 flex-none order-0 flex-grow-0 my-0 mr-2">
             <div class="static w-4 h-4 flex-none order-0 flex-grow-0 mr-2">
               <img
                 class="h-5 w-5 text-white"
@@ -17,7 +17,7 @@
                 src="../../../../../assets/images/chart-pie-svg.svg"
               >
             </div>
-            <div class="satic w-28 h-5 flex-none order-1 flex-grow-0">
+            <div class="satic w-auto h-5 flex-none order-1 flex-grow-0">
               {{ recipePortions + " porcion(es)" }}
             </div>
           </div>
@@ -30,7 +30,7 @@
                 src="../../../../../assets/images/clock-svg.svg"
               >
             </div>
-            <div class="static min-w-min h-5 flex-none order-1 flex-grow-0">
+            <div class="static w-auto h-5 flex-none order-1 flex-grow-0">
               {{ recipeMinutes + " minuto(s)" }}
             </div>
           </div>

--- a/app/javascript/components/recipes/show/recipe-info.vue
+++ b/app/javascript/components/recipes/show/recipe-info.vue
@@ -7,7 +7,7 @@
         svg-inline
         src="../../../../assets/images/dollar-svg.svg"
       >
-      <div class="w-10 h-5 font-sans font-normal text-base text-black flex-grow-0">
+      <div class="w-auto h-5 font-sans font-normal text-base text-black flex-grow-0">
         {{ recipePrice | currency }}
       </div>
     </div>
@@ -18,7 +18,7 @@
         svg-inline
         src="../../../../assets/images/chart-pie-svg.svg"
       >
-      <div class="w-24 h-5 font-sans font-normal text-base text-black flex-grow-0">
+      <div class="w-auto h-5 font-sans font-normal text-base text-black flex-grow-0">
         {{ portions }} {{ $t('msg.recipes.portions') }}
       </div>
     </div>
@@ -29,7 +29,7 @@
         svg-inline
         src="../../../../assets/images/clock-svg.svg"
       >
-      <div class="w-36 h-5 font-sans font-normal text-base text-black flex-grow-0">
+      <div class="w-auto h-5 font-sans font-normal text-base text-black flex-grow-0">
         {{ cookMinutes }} {{ $t('msg.recipes.minutes') }}
       </div>
     </div>


### PR DESCRIPTION
## Contexto
Las funcionalidades de la aplicación web están todas Ok pero siguen habiendo algunos detalles que arreglar

## Lo que hice
- Arreglar tabla de ingredientes para que no se pierda al hacer zoom.
- Arreglar tabla de menus para que no se pierda al hacer zoom. 
- Arreglar diseño del botón para editar varios inventarios ubicado en /ingredients 
- Arreglar la componente que contiene la información de una receta en /recipes para que si tiene muchas porciones o el tiempo es muy largo, no se pierda la información y se desforme.
- Arreglar la componente que contiene la información de una receta en /recipes/{id} para que si tiene muchas porciones o el tiempo es muy largo, no se pierda la información y se desforme.
- Hacer el form de proveedores responsive, para uqe no se desforme al hacer zoom

## QA
- ir a /ingredients y probar que no se pierda información de los ingredientes al jugar con el zoom y ver que el botón "editar varios inventarios" siga la linea del resto de los botones
- ir a /recipes y crear o editar una receta y ponerle un número con hartos dígitos en porciones y en tiempo y verificar que en /recipes y /recipes/{id} (correspondiente a esta receta) la información se vea de manera correcta
-  ir a /providers y apretar el botón de crear nuevo proveedor. Una vez que se abra el form, jugar con el zoom y verificr que no se desforme
