### PR TITLE
feat(scraper): return mapped measures

### DIFF
--- a/app/clients/cornershop_client.rb
+++ b/app/clients/cornershop_client.rb
@@ -35,7 +35,7 @@ class CornershopClient
 
       {
         price: get_price(product),
-        quantity: 1,
+        quantity: get_quantity(product),
         measure: get_measure(product),
         package: get_package(product),
         name: get_name(product),
@@ -51,7 +51,20 @@ class CornershopClient
   end
 
   def get_measure(product)
-    product['buy_unit']
+    MeasuresService.map_measure(package(product).split(' ').second)
+  end
+
+  def get_quantity(product)
+    quantity = package(product).split(' ').first.to_i
+
+    quantity.zero? ? 1 : quantity
+  end
+
+  def package(product)
+    elements = product['package']&.split(' ')
+    return '1 Unidad' unless elements&.count&.between?(2, 3)
+
+    elements.last(2).join(' ')
   end
 
   def get_package(product)

--- a/app/clients/jumbo_client.rb
+++ b/app/clients/jumbo_client.rb
@@ -61,7 +61,7 @@ class JumboClient < MarketClient
 
   def get_measure(product)
     measure = product.search('.shelf-single-unit').text.split(' ').second
-    format_search(measure)
+    MeasuresService.map_measure(format_search(measure))
   end
 
   def get_name(product)

--- a/app/clients/lider_client.rb
+++ b/app/clients/lider_client.rb
@@ -43,7 +43,7 @@ class LiderClient
   end
 
   def get_measure(product)
-    product.css('/div[2]/div[1]/div/span[1]').text.split(' ').second
+    MeasuresService.map_measure(product.css('/div[2]/div[1]/div/span[1]').text.split(' ').second)
   end
 
   def get_package(product)

--- a/app/services/measures_service.rb
+++ b/app/services/measures_service.rb
@@ -1,0 +1,17 @@
+class MeasuresService
+  KEYWORDS = {
+    'Kilo': %w(kg kilo kilos k),
+    'Gramo': %w(gr gramo gramos g),
+    'Litro': %w(l litro litros lt),
+    'Mililitro': %w(ml mililitro mililitros mls milis),
+    'Unidad': %w(u unidad unidades un)
+  }
+
+  def self.map_measure(measure)
+    KEYWORDS.each_pair do |keyword, values|
+      return keyword.to_s if values.include?(measure.downcase)
+    end
+
+    measure
+  end
+end

--- a/spec/clients/cornershop_client_spec.rb
+++ b/spec/clients/cornershop_client_spec.rb
@@ -65,16 +65,16 @@ RSpec.describe CornershopClient do
           [
             {
               price: 1950,
-              measure: "UN",
-              quantity: 1,
+              measure: "Gramo",
+              quantity: 600,
               package: "Bolsa 600 g",
               name: "Kingsbury - Pan molde perfecto blanco",
               img_url: "https://s.cornershopapp.com/img-url"
             },
             {
               price: 2250,
-              measure: "UN",
-              quantity: 1,
+              measure: "rebanadas",
+              quantity: 10,
               package: "Bolsa 10 rebanadas",
               name: "Ideal - Pan molde XL",
               img_url: "https://s.cornershopapp.com/img-url-2"

--- a/spec/clients/lider_client_spec.rb
+++ b/spec/clients/lider_client_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe LiderClient do
           products: [
             {
               price: 1990,
-              measure: 'g',
+              measure: 'Gramo',
               quantity: 500,
               package: '500 g',
               name: 'Carne Molida 4%',

--- a/spec/services/measures_service_spec.rb
+++ b/spec/services/measures_service_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe MeasuresService do
+  def run(scraped_measure)
+    MeasuresService.map_measure(scraped_measure)
+  end
+
+  describe 'map all the measures correctly' do
+    it 'returns correctly the mapped measures when exist' do
+      expect(run('l')).to eq('Litro')
+      expect(run('UNIDADES')).to eq('Unidad')
+      expect(run('kilo')).to eq('Kilo')
+    end
+
+    it 'does not map measures that does not exist' do
+      expect(run('lámina')).to eq('lámina')
+    end
+  end
+end


### PR DESCRIPTION
Base #154 

Creo un mapper para usar las measures que nosotros tenemos, para estandarizar. Ahora no siempre aparece "1 UN", si no que se transforman para usar las que tenemos en el dropdown original, a menos que sea diferente (y al final sería una measure custom).

Es decir, si aparece "Bolsa 300 g" -> `{ quantity: 300, measure: 'Gramo' }` como se ve en la foto

![image](https://user-images.githubusercontent.com/30879716/124398612-9aa39c80-dce4-11eb-9377-6fd45b231dbe.png)


### QA

Entrar a buscar ingredientes y que, al agregarlos, aparezcan las unidades correctas según lo que muestra la búsqueda:


https://user-images.githubusercontent.com/30879716/124398804-b6f40900-dce5-11eb-975b-daf94878f863.mov


Ojalá hacerlo con todo tipo de productos! no sé, "escoba", "cilantro", o cualquier cosa jajajaj