### PR TITLE
feat(auto-add-unit): auto add known unit conversions

### DIFF
--- a/app/javascript/components/ingredients/ingredients-form.vue
+++ b/app/javascript/components/ingredients/ingredients-form.vue
@@ -236,29 +236,32 @@ export default {
       this.autoAddUnit(unit);
     },
     autoAddUnit(currentUnit) {
+      const decimals = 100; // la cantidad de 0s es la cantidad de decimales que tendrá la conversion.
       const presentUnits = this.form.ingredientMeasuresAttributes.map((unit) => unit.name);
       if (this.directConvertions[currentUnit.name] && currentUnit.quantity !== undefined) {
-        for (const unit of Object.keys(this.directConvertions[currentUnit.name])) {
+        Object.keys(this.directConvertions[currentUnit.name]).forEach((unit) => {
           if (presentUnits.includes(unit)) {
             const unitsToUpdate = this.form.ingredientMeasuresAttributes.filter((obj) => obj.name === unit);
-            for (const toUpdate of unitsToUpdate) {
-              toUpdate.quantity = currentUnit.quantity / this.directConvertions[currentUnit.name][unit];
+            for (const unitToUpdate of unitsToUpdate) {
+              unitToUpdate.quantity = Math.round(
+                currentUnit.quantity * decimals / this.directConvertions[currentUnit.name][unit]) / decimals;
             }
           } else {
-            this.pushAutoUnit(unit, currentUnit.quantity / this.directConvertions[currentUnit.name][unit]);
+            this.pushAutoUnit(
+              unit,
+              Math.round(currentUnit.quantity * decimals / this.directConvertions[currentUnit.name][unit]) / decimals);
           }
-        }
+        });
       }
     },
     pushAutoUnit(name, quantity) {
       const lastItem = this.form.ingredientMeasuresAttributes[this.form.ingredientMeasuresAttributes.length - 1];
-      const incompletedLastItem = !lastItem.name || !lastItem.quantity;
-      if (incompletedLastItem) {
+      if (!lastItem.name || !lastItem.quantity) {
         this.form.ingredientMeasuresAttributes.pop(-1);
-      }
-      this.form.ingredientMeasuresAttributes.push({ name, quantity, id: undefined });
-      if (incompletedLastItem) {
+        this.form.ingredientMeasuresAttributes.push({ name, quantity, id: undefined });
         this.form.ingredientMeasuresAttributes.push(lastItem);
+      } else {
+        this.form.ingredientMeasuresAttributes.push({ name, quantity, id: undefined });
       }
     },
   },
@@ -275,7 +278,7 @@ export default {
       } = this.ingredient;
       let ingredientMeasuresAttributes;
       if (otherMeasures) {
-        ingredientMeasuresAttributes = otherMeasures.data.map(unit => /* eslint-disable-line camelcase */
+        ingredientMeasuresAttributes = otherMeasures.data.map(unit =>
           Object.assign({}, { id: unit.id }, unit.attributes),
         );
       } else {

--- a/app/javascript/components/ingredients/measure_search.vue
+++ b/app/javascript/components/ingredients/measure_search.vue
@@ -77,6 +77,11 @@ export default {
       return false;
     },
   },
+  watch: {
+    selectedMeasure() {
+      this.query = this.selectedMeasure;
+    },
+  },
 };
 
 </script>


### PR DESCRIPTION
# que se hizo?
- Se arregló un bug que hacia que no se actualizara bien en la vista al eliminar una medida.
- Para unidades con conversion conocida se añaden automanticamente sus conversiones cuando se agrega la medida.
# QA
Crear un ingrediente y al ponerle una medida con una transformacion conocida a otra unidad se debiesen agregar estas unidades tambien. Por ejemplo al agregar 3 Kilos se debiesen añadir automáticamente 3 gramos. Al eliminar una unidad no se elimina el resto de sus conversiones. Al editar una unidad sí se actualizan sus conversiones, y si estas no están, las crea.