### PR TITLE
fix(recipes): change measure when delete selected

### DIFF
--- a/app/models/ingredient_measure.rb
+++ b/app/models/ingredient_measure.rb
@@ -1,34 +1,9 @@
 class IngredientMeasure < ApplicationRecord
+  include PowerTypes::Observable
   belongs_to :ingredient
 
   validates :name, presence: true, uniqueness: { scope: :ingredient_id }
   validates :quantity, presence: true
-
-  before_save do
-    name.capitalize!
-    update_recipe_ingredient_if_exists
-  end
-
-  before_destroy { change_recipe_ingredient_if_exists }
-
-  def update_recipe_ingredient_if_exists
-    ingredient.recipe_ingredients.each do |recipe_ingredient|
-      next unless recipe_ingredient.ingredient_measure == name_was
-
-      recipe_ingredient.update!(ingredient_measure: name)
-    end
-  end
-
-  def change_recipe_ingredient_if_exists
-    ingredient.recipe_ingredients.each do |recipe_ingredient|
-      next unless recipe_ingredient.ingredient_measure == name_was
-
-      replacing_measure = ingredient.default_measure
-      name = replacing_measure.name
-      quantity = recipe_ingredient.ingredient_quantity / quantity_was * replacing_measure.quantity
-      recipe_ingredient.update!(ingredient_measure: name, ingredient_quantity: quantity)
-    end
-  end
 end
 
 # == Schema Information

--- a/app/models/ingredient_measure.rb
+++ b/app/models/ingredient_measure.rb
@@ -4,7 +4,31 @@ class IngredientMeasure < ApplicationRecord
   validates :name, presence: true, uniqueness: { scope: :ingredient_id }
   validates :quantity, presence: true
 
-  before_save { name.capitalize! }
+  before_save do
+    name.capitalize!
+    update_recipe_ingredient_if_exists
+  end
+
+  before_destroy { change_recipe_ingredient_if_exists }
+
+  def update_recipe_ingredient_if_exists
+    ingredient.recipe_ingredients.each do |recipe_ingredient|
+      next unless recipe_ingredient.ingredient_measure == name_was
+
+      recipe_ingredient.update!(ingredient_measure: name)
+    end
+  end
+
+  def change_recipe_ingredient_if_exists
+    ingredient.recipe_ingredients.each do |recipe_ingredient|
+      next unless recipe_ingredient.ingredient_measure == name_was
+
+      replacing_measure = ingredient.default_measure
+      name = replacing_measure.name
+      quantity = recipe_ingredient.ingredient_quantity / quantity_was * replacing_measure.quantity
+      recipe_ingredient.update!(ingredient_measure: name, ingredient_quantity: quantity)
+    end
+  end
 end
 
 # == Schema Information

--- a/app/observers/ingredient_measure_observer.rb
+++ b/app/observers/ingredient_measure_observer.rb
@@ -1,0 +1,28 @@
+class IngredientMeasureObserver < PowerTypes::Observer
+  before_save do
+    object.name.capitalize!
+    update_recipe_ingredient_if_exists
+  end
+
+  before_destroy :change_recipe_ingredient_if_exists
+
+  def update_recipe_ingredient_if_exists
+    object.ingredient.recipe_ingredients.each do |recipe_ingredient|
+      next unless recipe_ingredient.ingredient_measure == object.name_was
+
+      recipe_ingredient.update!(ingredient_measure: object.name)
+    end
+  end
+
+  def change_recipe_ingredient_if_exists
+    object.ingredient.recipe_ingredients.each do |recipe_ingredient|
+      next unless recipe_ingredient.ingredient_measure == object.name_was
+
+      replacing_measure = object.ingredient.default_measure
+      name = replacing_measure.name
+      quantity = recipe_ingredient.ingredient_quantity / object.quantity_was *
+        replacing_measure.quantity
+      recipe_ingredient.update!(ingredient_measure: name, ingredient_quantity: quantity)
+    end
+  end
+end

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -37,4 +37,38 @@ RSpec.describe Ingredient, type: :model do
       expect(described_class.below_minimum.count).to eq(ingredients_bad.count)
     end
   end
+
+  describe 'destroy of measure does not break recipe logic' do
+    let!(:recipe) { create(:recipe) }
+    let!(:ingredient) { create(:ingredient) }
+    let!(:first_ingredient_measure) do
+      create(:ingredient_measure, ingredient: ingredient, name: 'Kilo', quantity: 3, primary: true)
+    end
+    let!(:second_ingredient_measure) do
+      create(:ingredient_measure, ingredient: ingredient, name: 'Gramo', quantity: 3000)
+    end
+    let!(:recipe_ingredient) do
+      create(:recipe_ingredient, ingredient: ingredient, recipe: recipe,
+                                 ingredient_measure: 'Gramo', ingredient_quantity: 1500)
+    end
+
+    before do
+      ingredient.reload
+      recipe.reload
+    end
+
+    it 'changes ingredient measure name that is on recipe, so changes the name also' do
+      second_ingredient_measure.update!(name: 'Gramito')
+
+      expect(recipe_ingredient.reload.ingredient_measure).to eq('Gramito')
+      expect(recipe_ingredient.reload.ingredient_quantity).to eq(1500)
+    end
+
+    it 'deletes ingredient measure that is on recipe, but it changes to the existing one' do
+      second_ingredient_measure.destroy!
+
+      expect(recipe_ingredient.reload.ingredient_measure).to eq('Kilo')
+      expect(recipe_ingredient.reload.ingredient_quantity).to eq(1.5)
+    end
+  end
 end

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -37,38 +37,4 @@ RSpec.describe Ingredient, type: :model do
       expect(described_class.below_minimum.count).to eq(ingredients_bad.count)
     end
   end
-
-  describe 'destroy of measure does not break recipe logic' do
-    let!(:recipe) { create(:recipe) }
-    let!(:ingredient) { create(:ingredient) }
-    let!(:first_ingredient_measure) do
-      create(:ingredient_measure, ingredient: ingredient, name: 'Kilo', quantity: 3, primary: true)
-    end
-    let!(:second_ingredient_measure) do
-      create(:ingredient_measure, ingredient: ingredient, name: 'Gramo', quantity: 3000)
-    end
-    let!(:recipe_ingredient) do
-      create(:recipe_ingredient, ingredient: ingredient, recipe: recipe,
-                                 ingredient_measure: 'Gramo', ingredient_quantity: 1500)
-    end
-
-    before do
-      ingredient.reload
-      recipe.reload
-    end
-
-    it 'changes ingredient measure name that is on recipe, so changes the name also' do
-      second_ingredient_measure.update!(name: 'Gramito')
-
-      expect(recipe_ingredient.reload.ingredient_measure).to eq('Gramito')
-      expect(recipe_ingredient.reload.ingredient_quantity).to eq(1500)
-    end
-
-    it 'deletes ingredient measure that is on recipe, but it changes to the existing one' do
-      second_ingredient_measure.destroy!
-
-      expect(recipe_ingredient.reload.ingredient_measure).to eq('Kilo')
-      expect(recipe_ingredient.reload.ingredient_quantity).to eq(1.5)
-    end
-  end
 end

--- a/spec/observers/ingredient_measure_observer_spec.rb
+++ b/spec/observers/ingredient_measure_observer_spec.rb
@@ -10,12 +10,13 @@ describe IngredientMeasureObserver do
   end
 
   describe 'capitalize name of measure before save' do
-    let(:ingredient_measure) { create(:ingredient_measure) }
+    let!(:ingredient) { create(:ingredient) }
+    let!(:ingredient_measure) { create(:ingredient_measure, name: 'Kg', ingredient: ingredient) }
 
-    before { ingredient_measure.update!(name: 'kilo') }
+    before { ingredient_measure.update!(name: 'gramo') }
 
     it 'capializes the name' do
-      expect(ingredient_measure.name).to eq('Kilo')
+      expect(ingredient_measure.name).to eq('Gramo')
     end
   end
 

--- a/spec/observers/ingredient_measure_observer_spec.rb
+++ b/spec/observers/ingredient_measure_observer_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe IngredientMeasureObserver do
+  before do
+    PowerTypes::Observable.observable_disabled = false
+  end
+
+  after do
+    PowerTypes::Observable.observable_disabled = true
+  end
+
+  describe 'capitalize name of measure before save' do
+    let(:ingredient_measure) { create(:ingredient_measure) }
+
+    before { ingredient_measure.update!(name: 'kilo') }
+
+    it 'capializes the name' do
+      expect(ingredient_measure.name).to eq('Kilo')
+    end
+  end
+
+  describe 'destroy or update of measure does not break recipe logic' do
+    let!(:recipe) { create(:recipe) }
+    let!(:ingredient) { create(:ingredient) }
+    let!(:first_ingredient_measure) do
+      create(:ingredient_measure, ingredient: ingredient, name: 'Kilo', quantity: 3, primary: true)
+    end
+    let!(:second_ingredient_measure) do
+      create(:ingredient_measure, ingredient: ingredient, name: 'Gramo', quantity: 3000)
+    end
+    let!(:recipe_ingredient) do
+      create(:recipe_ingredient, ingredient: ingredient, recipe: recipe,
+                                 ingredient_measure: 'Gramo', ingredient_quantity: 1500)
+    end
+
+    before do
+      ingredient.reload
+      recipe.reload
+    end
+
+    it 'changes ingredient measure name that is on recipe, so changes the name also' do
+      second_ingredient_measure.update!(name: 'Gramito')
+
+      expect(recipe_ingredient.reload.ingredient_measure).to eq('Gramito')
+      expect(recipe_ingredient.reload.ingredient_quantity).to eq(1500)
+    end
+
+    it 'deletes ingredient measure that is on recipe, but it changes to the existing one' do
+      second_ingredient_measure.destroy!
+
+      expect(recipe_ingredient.reload.ingredient_measure).to eq('Kilo')
+      expect(recipe_ingredient.reload.ingredient_quantity).to eq(1.5)
+    end
+  end
+end

--- a/spec/swagger/v1/schemas/ingredient_schema.rb
+++ b/spec/swagger/v1/schemas/ingredient_schema.rb
@@ -14,7 +14,7 @@ INGREDIENT_SCHEMA = {
         type: :object,
         properties: {
           name: { type: :string, example: 'Kg', 'x-nullable': false },
-          quantity: { type: :integer, example: 1, 'x-nullable': true }
+          quantity: { type: :float, example: 1.2, 'x-nullable': true }
         }
       }
     }
@@ -42,7 +42,7 @@ INGREDIENT_RESPONSE_SCHEMA = {
         sku: { type: :string, example: 'SK28CD2', 'x-nullable': true },
         price: { type: :integer, example: 2990, 'x-nullable': true },
         currency: { type: :string, example: 'CLP', 'x-nullable': true },
-        quantity: { type: :integer, example: 2, 'x-nullable': true },
+        quantity: { type: :float, example: 2.4, 'x-nullable': true },
         measure: { type: :string, example: 'unidad', 'x-nullable': true },
         inventory: { type: :float, example: 10.3, 'x-nullable': true },
         minimum_quantity: { type: :float, example: 10.3, 'x-nullable': true },


### PR DESCRIPTION
Antes pasaba que, si teníamos:

Ingrediente con dos measures: 1 Kilo y 1000 Gramos. Una receta ocupando este ingrediente: 500 Gramos.

Si eliminamos los gramos o les cambiamos el nombre de las measures, las recetas tiraban error.

Ahora, cuando cambio el nombre entonces se actualiza tb en la receta y cuando se elimina entonces se cambia por otra (preferentemente la primary)

### QA

Ingrediente con dos measures: 1 Kilo y 1000 Gramos. Una receta ocupando este ingrediente: 500 Gramos.

Cambiar nombre de gramos, ver que cambió en la receta y el precio sigue el mismo (quantity consistente)
Eliminar gramos, precio sigue igual y cambia la measure (quantity consistente tb)