### PR TITLE
hot-fix(ingredientes-edit): available to edit ingredient

### DIFF
--- a/app/controllers/api/v1/ingredients_controller.rb
+++ b/app/controllers/api/v1/ingredients_controller.rb
@@ -55,7 +55,7 @@ class Api::V1::IngredientsController < Api::V1::BaseController
 
   def update
     if ingredient_params[:provider_name].blank?
-      respond_with ingredient.update!(ingredient_params)
+      respond_with ingredient.update!(ingredient_params.except(:provider_name))
     else
       provider = Provider.find_or_create_by(
         name: ingredient_params[:provider_name], user: current_user


### PR DESCRIPTION
Contexto:
- Había un error en el update que no dejaba actualizar los parametros de un ingrediente si es que no se le asignaba un proveedor.

Se solucionó el bug.

QA:
- Poder editar un ingrediente sin asignarlo proveedor.