### PR TITLE
Message inventory

### DIFF
--- a/app/controllers/api/v1/menus_controller.rb
+++ b/app/controllers/api/v1/menus_controller.rb
@@ -108,6 +108,7 @@ class Api::V1::MenusController < Api::V1::BaseController
       name: ingredient.name,
       measure: ingredient.measure,
       quantity: accumulated_quantity,
+      inventory: ingredient.inventory,
       total_price: ingredient.price.to_f / ingredient.quantity * accumulated_quantity
     }
   end

--- a/app/javascript/components/menus/index/menu-shopping-list.vue
+++ b/app/javascript/components/menus/index/menu-shopping-list.vue
@@ -57,7 +57,7 @@
             </div>
           </button>
           <button
-            class="focus:outline-none bg-gray-300 hover:bg-gray-400 p-4 mx-2 my-2 h-10 font-bold py-2 px-6 rounded shadow-md"
+            class="focus:outline-none bg-green-500 hover:bg-green-700 text-white p-4 mx-2 my-2 h-10 font-bold py-2 px-6 rounded shadow-md"
             @click="reduceInventory"
           >
             {{ $t('msg.menus.reduceInventory') }}

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -141,6 +141,25 @@
       >
         <p>{{ $t('msg.menus.reduceMsg') }}</p>
       </base-modal>
+      <base-modal
+        @cancel="toggleMessageReduction"
+        v-if="showReductionOfInventory"
+        :title="$t('msg.menus.reduceInventory')"
+        :cancel-button-label="$t('msg.cancel')"
+        :ok-button-present="false"
+      >
+        <div
+          v-for="(messages, idx) in ListMessages"
+          :key="idx"
+        >
+          <div
+            v-for="(message, msg_idx) in messages"
+            :key="msg_idx"
+          >
+            <p>{{ message }}</p>
+          </div>
+        </div>
+      </base-modal>
     </table>
   </div>
 </template>
@@ -149,7 +168,7 @@
 import MenusTableRecipesQuantity from './menus-table-recipes-quantity';
 import MenusTableRecipes from './menus-table-recipes';
 import MenuShoppingList from './menu-shopping-list';
-import { reduceInventoryApi } from '../../../api/menus';
+import { reduceInventoryApi, getShoppingList } from '../../../api/menus';
 import { unitaryPrice } from '../../../utils/recipeUtils.js';
 
 export default {
@@ -162,6 +181,7 @@ export default {
     return {
       error: '',
       showingReduceMsg: false,
+      showReductionOfInventory: false,
     };
   },
   props: {
@@ -175,6 +195,21 @@ export default {
       } catch (error) {
         this.error = error;
       }
+      const menuIngredientsResponse = await getShoppingList(this.idMenuToReduce);
+      this.menuIngredients = menuIngredientsResponse.data;
+      this.toggleMessageReduction();
+    },
+    toggleMessageReduction() {
+      this.ListMessages = this.getMessageofReduction(this.menuIngredients);
+      this.showReductionOfInventory = ! this.showReductionOfInventory;
+    },
+    getMessageofReduction(menuIngredients) {
+      const listOfMessages = menuIngredients.map((obj) =>
+        obj.ingredients.map((element) =>
+          `Has reducido ${element.quantity} ${element.measure} de ${element.name}`,
+        ));
+
+      return listOfMessages;
     },
     toggleReduce(menuId) {
       this.showingReduceMsg = !this.showingReduceMsg;

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -206,7 +206,8 @@ export default {
     getMessageofReduction(menuIngredients) {
       const listOfMessages = menuIngredients.map((obj) =>
         obj.ingredients.map((element) =>
-          `Has reducido ${element.quantity} ${element.measure} de ${element.name}`,
+          `Has reducido ${element.quantity} ${element.measure} de ${element.name} y quedaste en ${element.inventory}
+           ${element.measure}`,
         ));
 
       return listOfMessages;

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -145,7 +145,7 @@
         @cancel="toggleMessageReduction"
         v-if="showReductionOfInventory"
         :title="$t('msg.menus.reduceInventory')"
-        :cancel-button-label="$t('msg.cancel')"
+        :cancel-button-label="$t('msg.close')"
         :ok-button-present="false"
       >
         <div


### PR DESCRIPTION
### Contexto
Actualmente se puede reducir inventario desde Menus pero el usuario no sabe en cuanto quedó ni cuanto fue reducido. Para eso tenia que volver a ingredientes y revisar si bajó o no.

### Lo que se hizo
Luego de reducir el inventario se abre un modal que indica que ingredientes se fueron reducidos, en cuanto fueron reducidos y en cuanto quedó el inventario actual. (Deja como 0 si es negativo)

### QA
Crear ingredientes y agregarles inventario.
Crear recetas.
Crear menús.
Reducir el inventario y corroborar que los números son los correctos.


Aqui un ejemplo: 
![Captura de pantalla 2021-07-06 a la(s) 17 53 58](https://user-images.githubusercontent.com/48296628/124671234-30752e00-de83-11eb-8f9a-b82d53c4a216.png)
