### PR TITLE
feat(users): recover password by email

### DIFF
--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -25,6 +25,12 @@ class Api::V1::Users::RegistrationsController < Devise::RegistrationsController
     end
   end
 
+  def forgot_password
+    user_email = forgot_password_params[:email]
+
+    respond_with User.find_by!(email: user_email).send_reset_password_instructions
+  end
+
   private
 
   def user_params
@@ -33,5 +39,9 @@ class Api::V1::Users::RegistrationsController < Devise::RegistrationsController
 
   def change_password_params
     params.require(:user).permit(:password, :password_confirmation)
+  end
+
+  def forgot_password_params
+    params.require(:user).permit(:email)
   end
 end

--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -28,7 +28,11 @@ class Api::V1::Users::RegistrationsController < Devise::RegistrationsController
   def forgot_password
     user_email = forgot_password_params[:email]
 
-    respond_with User.find_by!(email: user_email).send_reset_password_instructions
+    respond_with begin
+      User.find_by!(email: user_email).send_reset_password_instructions
+
+      true
+    end
   end
 
   private

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,0 +1,30 @@
+
+
+<div class="pt-8 px-4 m-auto max-w-xs">
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4" }) do |f| %>
+    <h2 class="pb-5 text-4xl text-center">
+      <%= I18n.t('devise.recover-password') %>
+    </h2>
+
+    <div class="pb-2">
+      <% resource.errors.full_messages.each do |msg| %>
+        <p class="mt-2 ml-1 text-xs text-red-400"><%= msg %></p>
+      <% end %>
+    </div>
+    <%= f.hidden_field :reset_password_token %>
+
+    <div class="flex flex-col pb-2">
+      <%= f.label :password, I18n.t('devise.new-password'), class: "text-gray-700 text-sm font-bold mb-2" %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
+    </div>
+
+    <div class="flex flex-col pb-2">
+      <%= f.label :password_confirmation, I18n.t('devise.confirm-password'), class: "text-gray-700 text-sm font-bold mb-2" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
+    </div>
+
+    <div class="flex justify-center pt-4">
+      <%= f.submit I18n.t('devise.confirm'), class: 'cursor-pointer font-bold py-2 text-center rounded shadow-md w-full h-auto focus:outline-none bg-green-500 hover:bg-green-700 text-white' %>
+    </div>
+  <% end %>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,7 @@
 Rails.application.configure do
   config.active_job.queue_adapter = :async
   config.action_mailer.delivery_method = :sendgrid_dev
+  config.action_mailer.default_url_options = { host: 'localhost' }
   Rails.application.config.action_mailer.sendgrid_dev_settings = {
     api_key: ENV['SENDGRID_API_KEY']
   }

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -9,3 +9,8 @@ es-CL:
   alerts:
     scraper: 'Estamos teniendo problemas para obtener productos de más supermercados.'
     scraper-failed: 'Ocurrió un problema. Por favor ingresa productos manualmente.'
+  devise:
+    recover-password: 'Recupera tu contraseña'
+    new-password: 'Nueva contraseña'
+    confirm-password: 'Confirmar contraseña'
+    confirm: 'Confirmar'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
         devise_scope :user do
           resources :registrations, only: [:create]
           post '/change-password', to: 'registrations#change_password'
+          post '/forgot-password', to: 'registrations#forgot_password'
           resources :sessions, only: [:create]
         end
       end

--- a/spec/integration/api/v1/registrations_spec.rb
+++ b/spec/integration/api/v1/registrations_spec.rb
@@ -1,6 +1,6 @@
 require 'swagger_helper'
 
-# rubocop:disable RSpec/EmptyExampleGroup
+# rubocop:disable RSpec/EmptyExampleGroup, RSpec/MultipleMemoizedHelpers
 describe 'API::V1::Registrations', swagger_doc: 'v1/swagger.json' do
   path '/users/registrations' do
     post 'Create user' do
@@ -89,5 +89,46 @@ describe 'API::V1::Registrations', swagger_doc: 'v1/swagger.json' do
       end
     end
   end
+
+  path '/users/forgot-password' do
+    post 'Send email for recover password tro user' do
+      consumes 'application/json'
+      produces 'application/json'
+      parameter(
+        name: :user,
+        in: :body,
+        schema: {
+          type: "object",
+          properties: {
+            user: { "$ref" => "#/definitions/forgot_password" }
+          },
+          required: [
+            :user
+          ]
+        }
+      )
+
+      let!(:user_who_forgot) { create(:user, email: 'someone@mail.com') }
+
+      response '201', 'recover password email correctly sent' do
+        let(:user) do
+          {
+            user: {
+              email: 'someone@mail.com'
+            }
+          }
+        end
+
+        let(:mail) { instance_double('mailer', deliver: true) }
+
+        before { allow(Devise::Mailer).to receive(:reset_password_instructions).and_return(mail) }
+
+        run_test! do
+          expect(Devise::Mailer).to have_received(:reset_password_instructions)
+          expect(user_who_forgot.reload.reset_password_token).not_to be_nil
+        end
+      end
+    end
+  end
 end
-# rubocop:enable RSpec/EmptyExampleGroup
+# rubocop:enable RSpec/EmptyExampleGroup, RSpec/MultipleMemoizedHelpers

--- a/spec/swagger/v1/definition.rb
+++ b/spec/swagger/v1/definition.rb
@@ -22,6 +22,7 @@ API_V1 = {
     recipe_critical_associations: RECIPE_CRITICAL_ASSOCIATIONS,
     user: USER_SCHEMA,
     change_password: CHANGE_PASSWORD_SCHEMA,
+    forgot_password: FORGOT_PASSWORD_SCHEMA,
     provider_ingredient: PROVIDER_INGREDIENT_SCHEMA,
     cornershop_product: CORNERSHOP_PRODUCT_SCHEMA,
     ingredient: INGREDIENT_SCHEMA,

--- a/spec/swagger/v1/schemas/user_schema.rb
+++ b/spec/swagger/v1/schemas/user_schema.rb
@@ -15,3 +15,10 @@ CHANGE_PASSWORD_SCHEMA = {
     password_confirmation: { type: :string }
   }
 }
+
+FORGOT_PASSWORD_SCHEMA = {
+  type: :object,
+  properties: {
+    email: { type: :string }
+  }
+}

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -341,6 +341,14 @@
         }
       }
     },
+    "forgot_password": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        }
+      }
+    },
     "provider_ingredient": {
       "type": "object",
       "properties": {
@@ -2792,6 +2800,39 @@
           },
           "400": {
             "description": "new password and confirmation are not the same"
+          }
+        }
+      }
+    },
+    "/users/forgot-password": {
+      "post": {
+        "summary": "Send email for recover password tro user",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "user",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "user": {
+                  "$ref": "#/definitions/forgot_password"
+                }
+              },
+              "required": [
+                "user"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "recover password email correctly sent"
           }
         }
       }


### PR DESCRIPTION
BASE #176 

Agrego recuperar contraseña por mail. Ejemplo:

![image](https://user-images.githubusercontent.com/30879716/125175828-c61eff00-e19c-11eb-8da9-9800ac2fccf0.png)

Esto envía un mail a el usuario solo si existe:
![image](https://user-images.githubusercontent.com/30879716/125175831-d3d48480-e19c-11eb-81ba-4aeb9973502e.png)

Luego puede cambiar su contraseña (la idea es que se abra esta página tanto cuando estás en mobile o en web):
![image](https://user-images.githubusercontent.com/30879716/125175834-eb137200-e19c-11eb-92cb-5cdaaf8395f7.png)

Después te redirige al /home


### QA

- Usar el endpoint, pero primero esperar que respondan de SendGrid porq estamos banneaos 😢  dejé un ticket