### PR TITLE
style(app): general style

### DIFF
--- a/app/javascript/components/base/dots-dropdown.vue
+++ b/app/javascript/components/base/dots-dropdown.vue
@@ -71,8 +71,8 @@ export default {
   computed: {
     dropdownStyle() {
       const baseStyle = 'mt-0.5 w-32 bg-white border overflow-hidden rounded-lg shadow-md cursor-pointer z-10 ';
-      const notLastStyle = '-left-20 absolute';
-      const lastStyle = '-left-20 bottom-10 absolute';
+      const notLastStyle = '-left-24 absolute';
+      const lastStyle = '-left-24 bottom-10 absolute';
       if (!this.elements.last) {
         return baseStyle + notLastStyle;
       }

--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -6,7 +6,7 @@
         {{ $t('msg.ingredients.title') }}
       </div>
       <span
-        class="flex my-auto w-8 h-8 pl-2 ml-2"
+        class="flex m-auto w-8 h-8 ml-2"
         v-if="loading"
       >
         <base-spinner />
@@ -157,7 +157,7 @@
     >
       <!-- Critical associations -->
       <span
-        class="flex my-auto w-8 h-8 pl-2"
+        class="flex m-auto w-8 h-8"
         v-if="loadingAssociations"
       >
         <base-spinner />

--- a/app/javascript/components/ingredients/ingredients-edit-inventory.vue
+++ b/app/javascript/components/ingredients/ingredients-edit-inventory.vue
@@ -14,7 +14,7 @@
           {{ $t('msg.ingredients.inventory.editingInventories') }}
         </div>
         <span
-          class="flex my-auto w-8 h-8 pl-2 ml-2"
+          class="flex m-auto w-8 h-8 ml-2"
           v-if="loading"
         >
           <base-spinner />

--- a/app/javascript/components/ingredients/ingredients-form.vue
+++ b/app/javascript/components/ingredients/ingredients-form.vue
@@ -128,8 +128,8 @@
                 @selectMeasure="changeUnitName(unit, ...arguments)"
               />
               <button
-                type="button text-black"
-                class="px-3"
+                type="button"
+                class="px-3 text-black focus:outline-none"
                 v-if="index > 0"
                 @click="deleteUnit(unit)"
               >

--- a/app/javascript/components/ingredients/ingredients-table.vue
+++ b/app/javascript/components/ingredients/ingredients-table.vue
@@ -174,11 +174,8 @@ export default {
     },
     lastIngredient(idx) {
       const finalRowsCount = 2;
-      if (idx >= this.ingredients.length - finalRowsCount) {
-        return true;
-      }
 
-      return false;
+      return idx >= this.ingredients.length - finalRowsCount;
     },
   },
 };

--- a/app/javascript/components/ingredients/ingredients-table.vue
+++ b/app/javascript/components/ingredients/ingredients-table.vue
@@ -120,8 +120,8 @@
           <td class="content-center">
             <dots-dropdown
               :elements="{
-                edit:true,
-                del:true,
+                edit: true,
+                del: true,
                 last: lastIngredient(idx)
               }"
               @edit="editIngredient(ingredient)"
@@ -173,7 +173,8 @@ export default {
       }
     },
     lastIngredient(idx) {
-      if (idx === this.ingredients.length - 1) {
+      const finalRowsCount = 2;
+      if (idx >= this.ingredients.length - finalRowsCount) {
         return true;
       }
 

--- a/app/javascript/components/ingredients/search-market-ingredients.vue
+++ b/app/javascript/components/ingredients/search-market-ingredients.vue
@@ -38,7 +38,7 @@
               v-else
             >
               <span
-                class="flex my-auto w-8 h-8 pl-2"
+                class="flex m-auto w-8 h-8"
               >
                 <base-spinner />
               </span>

--- a/app/javascript/components/menus/base/selected-recipes-card.vue
+++ b/app/javascript/components/menus/base/selected-recipes-card.vue
@@ -45,11 +45,11 @@
     <!-- button -->
     <div class="flex flex-col justify-center items-end h-20 flex-none self-stretch mr-2">
       <button
-        class="w-3 h-3 bg-red-500 shadow-sm rounded-md flex-none mb-1.5 focus:outline-none"
+        class="w-4 h-4 bg-white-500 rounded-md mb-1.5 focus:outline-none"
         @click="deleteRecipe"
       >
         <img
-          class="h-3 w-3 text-white m-auto"
+          class="h-4 w-4 text-white m-auto"
           svg-inline
           src="../../../../assets/images/cross-svg.svg"
         >

--- a/app/javascript/components/menus/edit/edit-menu-container.vue
+++ b/app/javascript/components/menus/edit/edit-menu-container.vue
@@ -117,7 +117,7 @@
             </div>
             <span
               v-if="loading"
-              class="flex my-auto w-8 h-8 pl-2 ml-2"
+              class="flex m-auto w-8 h-8 ml-2"
             >
               <base-spinner />
             </span>
@@ -130,7 +130,7 @@
               {{ $t('msg.menus.selectedRecipes') }} ({{ selectedRecipes.length }})
               <span
                 v-if="loading"
-                class="flex my-auto w-8 h-8 pl-2 ml-2"
+                class="flex m-auto w-8 h-8 ml-2"
               >
                 <base-spinner />
               </span>
@@ -312,12 +312,15 @@ export default {
       this.selectedRecipes.splice(indexToUpdate, 1, { ...recipe, quantity: newValue });
     },
     decreaseQuantity(recipe) {
-      if (recipe.quantity <= 1) return;
-      const newValue = recipe.quantity -= 1;
+      if (recipe.quantity <= 1) {
+        this.deleteRecipe(recipe);
+      } else {
+        const newValue = recipe.quantity -= 1;
 
-      const indexToUpdate = this.selectedRecipes.findIndex((element) =>
-        parseInt(element.id, 10) === parseInt(recipe.id, 10));
-      this.selectedRecipes.splice(indexToUpdate, 1, { ...recipe, quantity: newValue });
+        const indexToUpdate = this.selectedRecipes.findIndex((element) =>
+          parseInt(element.id, 10) === parseInt(recipe.id, 10));
+        this.selectedRecipes.splice(indexToUpdate, 1, { ...recipe, quantity: newValue });
+      }
     },
     getUpdatedMenu() {
       const updatedMenu = { name: this.menuName,

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -246,7 +246,12 @@ export default {
       return returnArray;
     },
     lastMenu(idx) {
-      return (idx === this.menus.length - 1);
+      const finalRowsCount = 2;
+      if (idx >= this.menus.length - finalRowsCount) {
+        return true;
+      }
+
+      return false;
     },
   },
 };

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -247,11 +247,8 @@ export default {
     },
     lastMenu(idx) {
       const finalRowsCount = 2;
-      if (idx >= this.menus.length - finalRowsCount) {
-        return true;
-      }
 
-      return false;
+      return idx >= this.menus.length - finalRowsCount;
     },
   },
 };

--- a/app/javascript/components/menus/new/new-menu-container.vue
+++ b/app/javascript/components/menus/new/new-menu-container.vue
@@ -117,7 +117,7 @@
             </div>
             <span
               v-if="loading"
-              class="flex my-auto w-8 h-8 pl-2 ml-2"
+              class="flex m-auto w-8 h-8 ml-2"
             >
               <base-spinner />
             </span>
@@ -130,7 +130,7 @@
               {{ $t('msg.menus.selectedRecipes') }} ({{ selectedRecipes.length }})
               <span
                 v-if="loading"
-                class="flex my-auto w-8 h-8 pl-2 ml-2"
+                class="flex m-auto w-8 h-8 ml-2"
               >
                 <base-spinner />
               </span>
@@ -263,11 +263,14 @@ export default {
       this.selectedRecipes.splice(indexToUpdate, 1, { ...recipe, quantity: newValue });
     },
     decreaseQuantity(recipe) {
-      if (recipe.quantity <= 1) return;
-      const newValue = recipe.quantity -= 1;
-      const indexToUpdate = this.selectedRecipes.findIndex((element) =>
-        parseInt(element.id, 10) === parseInt(recipe.id, 10));
-      this.selectedRecipes.splice(indexToUpdate, 1, { ...recipe, quantity: newValue });
+      if (recipe.quantity <= 1) {
+        this.deleteRecipe(recipe);
+      } else {
+        const newValue = recipe.quantity -= 1;
+        const indexToUpdate = this.selectedRecipes.findIndex((element) =>
+          parseInt(element.id, 10) === parseInt(recipe.id, 10));
+        this.selectedRecipes.splice(indexToUpdate, 1, { ...recipe, quantity: newValue });
+      }
     },
 
     async createMenu() {

--- a/app/javascript/components/recipes/base/recipe-ingredients.vue
+++ b/app/javascript/components/recipes/base/recipe-ingredients.vue
@@ -37,7 +37,7 @@
         </div>
         <span
           v-if="loading"
-          class="flex my-auto w-8 h-8 pl-2 ml-2"
+          class="flex m-auto w-8 h-8 ml-2"
         >
           <base-spinner />
         </span>
@@ -50,7 +50,7 @@
           {{ $t('msg.recipes.selectedIngredients') }} ({{ recipeIngredients.length }})
           <span
             v-if="loading"
-            class="flex my-auto w-8 h-8 pl-2 ml-2"
+            class="flex m-auto w-8 h-8 ml-2"
           >
             <base-spinner />
           </span>

--- a/app/javascript/components/recipes/base/recipe-steps.vue
+++ b/app/javascript/components/recipes/base/recipe-steps.vue
@@ -179,11 +179,8 @@ export default {
     },
     lastStep(idx) {
       const finalRowsCount = 2;
-      if (idx >= this.recipeSteps.length - finalRowsCount) {
-        return true;
-      }
 
-      return false;
+      return idx >= this.recipeSteps.length - finalRowsCount;
     },
   },
 };

--- a/app/javascript/components/recipes/base/recipe-steps.vue
+++ b/app/javascript/components/recipes/base/recipe-steps.vue
@@ -178,7 +178,12 @@ export default {
       this.modifiedRecipeSteps[idx].isEditing = !this.modifiedRecipeSteps[idx].isEditing;
     },
     lastStep(idx) {
-      return (idx === this.recipeSteps.length - 1);
+      const finalRowsCount = 2;
+      if (idx >= this.recipeSteps.length - finalRowsCount) {
+        return true;
+      }
+
+      return false;
     },
   },
 };

--- a/app/javascript/components/recipes/base/selected-ingredient-card.vue
+++ b/app/javascript/components/recipes/base/selected-ingredient-card.vue
@@ -52,11 +52,11 @@
     <!-- button -->
     <div class="flex flex-col justify-center items-end h-20 flex-none self-stretch mr-2">
       <button
-        class="w-3 h-3 bg-red-500 shadow-sm rounded-md flex-none flex-grow-0 mb-1.5 focus:outline-none"
+        class="w-4 h-4 bg-white-500 rounded-md mb-1.5 focus:outline-none"
         @click="deleteIngredient"
       >
         <img
-          class="h-3 w-3 text-white m-auto"
+          class="h-4 w-4 text-white m-auto"
           svg-inline
           src="../../../../assets/images/cross-svg.svg"
         >

--- a/app/javascript/components/recipes/index/recipes-container.vue
+++ b/app/javascript/components/recipes/index/recipes-container.vue
@@ -6,7 +6,7 @@
         {{ $t('msg.recipes.title') }}
       </div>
       <span
-        class="flex my-auto w-8 h-8 pl-2 ml-2"
+        class="flex m-auto w-8 h-8 ml-2"
         v-if="loading"
       >
         <base-spinner />

--- a/app/javascript/components/recipes/new/recipe-create.vue
+++ b/app/javascript/components/recipes/new/recipe-create.vue
@@ -13,7 +13,7 @@
         {{ $t('msg.recipes.create') }}
       </div>
       <span
-        class="flex my-auto w-8 h-8 pl-2 ml-2"
+        class="flex m-auto w-8 h-8 ml-2"
         v-if="loading"
       >
         <base-spinner />

--- a/app/javascript/components/recipes/show/recipe-show.vue
+++ b/app/javascript/components/recipes/show/recipe-show.vue
@@ -13,7 +13,7 @@
         {{ this.recipe.name }}
       </div>
       <span
-        class="flex my-auto w-8 h-8 pl-2 ml-2"
+        class="flex m-auto w-8 h-8 ml-2"
         v-if="loading"
       >
         <base-spinner />
@@ -68,7 +68,7 @@
     >
       <!-- Critical associations -->
       <span
-        class="flex my-auto w-8 h-8 pl-2"
+        class="flex m-auto w-8 h-8"
         v-if="loadingAssociations"
       >
         <base-spinner />


### PR DESCRIPTION

Algunas cosillas:

- Ahora los modals para editar/eliminar se abren más a la izquierda para que nunca aparezca el scroll en pantalla normal. Además, los dos últimos se abren hacia arriba (en vez de solo el último)
- Spinners centrados en los modals
- Borders de algunos botones al apretarlos
- Ahora se puede eliminar una receta en un menú al bajar su cantidad < 1. También cambié los botones de eliminar una receta o ingrediente seleccionado en menu - receta respectivamente