### PR TITLE
fix(scraper): change to camelcase attribute of provider

### DIFF
--- a/app/javascript/components/ingredients/search-market-ingredients.vue
+++ b/app/javascript/components/ingredients/search-market-ingredients.vue
@@ -137,12 +137,12 @@ export default {
     addMarketIngredient(productIdx) {
       const productInfo = this.productsByMarket[this.market].products[productIdx];
       const productForm = {
-        provider_name: this.productsByMarket[this.market].provider.name, /* eslint-disable-line camelcase */
+        providerName: this.productsByMarket[this.market].provider.name,
         name: productInfo.name,
         sku: null,
         price: productInfo.price,
         currency: 'CLP',
-        ingredientMeasuresAttributes: [ /* eslint-disable-line camelcase */
+        ingredientMeasuresAttributes: [
           { name: productInfo.measure, quantity: productInfo.quantity }],
       };
       this.$emit('submit', productForm);


### PR DESCRIPTION
Cuando se agregaba un proveedor mediante proveedor no se estaba pasando el scraper porque no estaba con camelCase el atributo cuando se transformó todo.

Ahora sí ya no queda ningún `/* eslint-disable-line camelcase */` en el código (lo cual estaba mal)