### PR TITLE
feat(app): disable provider and strange loadings

### DIFF
--- a/app/javascript/components/ingredients/ingredients-form.vue
+++ b/app/javascript/components/ingredients/ingredients-form.vue
@@ -41,6 +41,7 @@
             class="block w-full bg-white text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none"
             v-model="form.providerName"
             id="ingredient-provider"
+            :disabled="!editMode && marketIngredient !== undefined"
           >
             <!--Add Mode unit from market -->
             <option

--- a/app/javascript/components/menus/edit/edit-menu-container.vue
+++ b/app/javascript/components/menus/edit/edit-menu-container.vue
@@ -257,15 +257,12 @@ export default {
 
     async editMenu() {
       if (this.validations()) {
-        this.loading = true;
         try {
           const updatedMenu = this.getUpdatedMenu();
           await updateMenu(this.menuId, updatedMenu);
           window.location = '/menus';
         } catch (error) {
           this.error = true;
-        } finally {
-          this.loading = false;
         }
       }
     },

--- a/app/javascript/components/recipes/edit/recipe-edit.vue
+++ b/app/javascript/components/recipes/edit/recipe-edit.vue
@@ -191,15 +191,12 @@ export default {
     },
     async editRecipe() {
       if (this.validations()) {
-        this.loading = true;
         try {
           const updatedRecipe = this.getUpdatedRecipe();
           await updateRecipe(this.recipe.id, updatedRecipe);
           window.location = `/recipes/${this.recipeId}`;
         } catch (error) {
           this.error = true;
-        } finally {
-          this.loading = false;
         }
       }
     },


### PR DESCRIPTION
Algunos detallitos chicos:

- Cuando un producto viene del scraper, deshabilito la opción de cambiar el proveedor (viene por defecto)
- Saco los loadings al momento de crear una receta o menú. Como es tan poco el tiempo que demora, se alcanzaba a ver como que se desconfiguraba toda la página y se veía raro (porq con loading desaparecen divs)