### PR TITLE
refactor(validations): add refactor to validations for ingredients, recipes and menus

### DIFF
--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -13,24 +13,13 @@
       </span>
     </div>
 
-    <!-- Alert -->
-    <div
-      v-if="unexpectedError"
-      class="mt-4 w-max bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded relative"
-      role="alert"
-    >
-      <span class="mr-7 block sm:inline">{{ $t('msg.unexpectedError') }}</span>
-      <span
-        class="absolute top-0 bottom-0 right-0 px-4 py-3 cursor-pointer"
-        @click="closeAlert"
-      >
-        <img
-          svg-inline
-          src="../../../assets/images/cancel-red-svg.svg"
-          class="h-5 w-5 text-red-700"
-        >
-      </span>
-    </div>
+    <!-- Alert unexpected error -->
+    <base-alert
+      :variable="unexpectedError"
+      :alert-name="'unexpectedError'"
+      :success="false"
+      @closeAlert="closeAlert"
+    />
 
     <div class="flex flex-col pt-6 pb-10 px-10 w-auto h-auto bg-gray-50 my-10">
       <!--SearchBar y Button-->
@@ -340,9 +329,6 @@ export default {
     // eslint-disable-next-line max-statements
     async editIngredient() {
       const ingredientsInfo = this.$refs.editIngredientInfo.form;
-      if (this.checkErrorsEditIngredient(ingredientsInfo)) {
-        return;
-      }
       if (this.validations(this.$refs.editIngredientInfo.form)) {
         try {
           this.showingEdit = !this.showingEdit;
@@ -360,27 +346,7 @@ export default {
         }
       }
     },
-    checkErrorsEditIngredient(info) {
-      if (!info.name || !info.ingredientMeasuresAttributes[0].quantity ||
-      !info.ingredientMeasuresAttributes[0].name) {
-        // eslint-disable-next-line no-alert
-        alert(this.$t('msg.ingredients.msjAlert'));
 
-        return true;
-      } else if (info.ingredientMeasuresAttributes[0].quantity < 1) {
-        // eslint-disable-next-line no-alert
-        alert(this.$t('msg.ingredients.msjMinQuantity'));
-
-        return true;
-      } else if (info.minimumQuantity < 0) {
-        // eslint-disable-next-line no-alert
-        alert(this.$t('msg.ingredients.msjNegativeQuantity'));
-
-        return true;
-      }
-
-      return false;
-    },
     addMeasuresToDelete(ingredientsInfo) {
       this.$refs.editIngredientInfo.measuresToDelete
         .forEach(elem => ingredientsInfo.ingredientMeasuresAttributes.push({ id: elem, _destroy: true }));

--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -397,7 +397,6 @@ export default {
       };
     },
 
-    // eslint-disable-next-line max-statements
     validations(form) {
       this.cleanErrors();
 
@@ -411,9 +410,7 @@ export default {
       this.errors.measure = requiredField(form.ingredientMeasuresAttributes[0].name, this.errors.measure);
       this.errors.price = requiredField(form.price, this.errors.price);
 
-      const validForm = !(Object.values(this.errors).some(value => !!value));
-
-      return validForm;
+      return !(Object.values(this.errors).some(value => !!value));
     },
   },
 };

--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -173,6 +173,7 @@
 import Vue from 'vue';
 import { getIngredients, postIngredient, deleteIngredient,
   editIngredient, getCriticalAssociations } from './../../api/ingredients.js';
+import { floatNonZero, intGeqZero, geqZero, requiredField } from '../../utils/validations.js';
 import IngredientsForm from './ingredients-form';
 import IngredientsTable from './ingredients-table';
 import SearchMarketIngredients from './search-market-ingredients';
@@ -396,39 +397,19 @@ export default {
       };
     },
 
-    // eslint-disable-next-line max-statements,complexity
+    // eslint-disable-next-line max-statements
     validations(form) {
       this.cleanErrors();
 
       const quantity = form.ingredientMeasuresAttributes[0].quantity;
 
-      if (!(typeof (quantity - 0) === 'number') || !(quantity > 0)) {
-        this.errors.quantity = 'floatNonZero';
-      }
-
-      if (!(Number.isInteger(form.price - 0)) || !(form.price >= 0)) {
-        this.errors.price = 'intGeqZero';
-      }
-
-      if (form.minimumQuantity && !(form.minimumQuantity >= 0)) {
-        this.errors.minimumQuantity = 'geqZero';
-      }
-
-      if (!form.name) {
-        this.errors.name = 'requiredField';
-      }
-
-      if (!form.ingredientMeasuresAttributes[0].quantity) {
-        this.errors.quantity = 'requiredField';
-      }
-
-      if (!form.ingredientMeasuresAttributes[0].name) {
-        this.errors.measure = 'requiredField';
-      }
-
-      if (!form.price) {
-        this.errors.price = 'requiredField';
-      }
+      this.errors.quantity = floatNonZero(quantity, this.errors.quantity);
+      this.errors.price = intGeqZero(form.price, this.errors.price);
+      this.errors.minimumQuantity = geqZero(form.minimumQuantity, this.errors.minimumQuantity);
+      this.errors.name = requiredField(form.name, this.errors.name);
+      this.errors.quantity = requiredField(quantity, this.errors.quantity);
+      this.errors.measure = requiredField(form.ingredientMeasuresAttributes[0].name, this.errors.measure);
+      this.errors.price = requiredField(form.price, this.errors.price);
 
       const validForm = !(Object.values(this.errors).some(value => !!value));
 

--- a/app/javascript/components/ingredients/ingredients-form.vue
+++ b/app/javascript/components/ingredients/ingredients-form.vue
@@ -17,12 +17,9 @@
             :placeholder="$t('msg.ingredients.name')"
             v-model="form.name"
           >
-          <p
-            v-if="ingredientErrors.name"
-            class="mt-2 ml-1 text-xs text-red-400"
-          >
-            {{ $t(`msg.${ingredientErrors.name}`) }}
-          </p>
+          <base-error-paragraph
+            :msg-error="ingredientErrors.name"
+          />
         </div>
       </div>
 
@@ -95,12 +92,9 @@
               :placeholder="unit.name"
               @change="autoAddUnit(unit)"
             >
-            <p
-              v-if="ingredientErrors.quantity"
-              class="mt-2 ml-1 text-xs text-red-400"
-            >
-              {{ $t(`msg.${ingredientErrors.quantity}`) }}
-            </p>
+            <base-error-paragraph
+              :msg-error="ingredientErrors.quantity"
+            />
           </div>
           <div class="w-full px-3 mb-6 md:mb-0">
             <!--Measure -->
@@ -140,12 +134,9 @@
                 >
               </button>
             </div>
-            <p
-              v-if="ingredientErrors.measure"
-              class="mt-2 ml-1 text-xs text-red-400"
-            >
-              {{ $t(`msg.${ingredientErrors.measure}`) }}
-            </p>
+            <base-error-paragraph
+              :msg-error="ingredientErrors.measure"
+            />
           </div>
         </div>
         <div
@@ -177,12 +168,9 @@
             type="number"
             :placeholder="$t('msg.ingredients.price')"
           >
-          <p
-            v-if="ingredientErrors.price"
-            class="mt-2 ml-1 text-xs text-red-400"
-          >
-            {{ $t(`msg.${ingredientErrors.price}`) }}
-          </p>
+          <base-error-paragraph
+            :msg-error="ingredientErrors.price"
+          />
           <!--Minimum Quantity -->
           <label
             class="block text-gray-700 text-sm font-bold mb-2 mt-4"
@@ -206,12 +194,9 @@
             type="number"
             :placeholder="$t('msg.ingredients.quantity')"
           >
-          <p
-            v-if="ingredientErrors.minimumQuantity"
-            class="mt-2 ml-1 text-xs text-red-400"
-          >
-            {{ $t(`msg.${ingredientErrors.minimumQuantity}`) }}
-          </p>
+          <base-error-paragraph
+            :msg-error="ingredientErrors.minimumQuantity"
+          />
         </div>
       </div>
     </form>

--- a/app/javascript/components/ingredients/search-market-ingredients.vue
+++ b/app/javascript/components/ingredients/search-market-ingredients.vue
@@ -119,7 +119,7 @@ export default {
     return {
       scraperProblems: null,
       loading: false,
-      unexpectedError: true,
+      unexpectedError: false,
       errors: { query: '' },
       query: '',
       productsByMarket: [],

--- a/app/javascript/components/ingredients/search-market-ingredients.vue
+++ b/app/javascript/components/ingredients/search-market-ingredients.vue
@@ -1,8 +1,15 @@
 <template>
-  <div class="pt-3 h-full w-96">
+  <div class="h-full w-96">
     <div>
       <div class="flex flex-wrap -mx-3 mb-6">
-        <div class="w-full px-3">
+        <!-- Alert unexpected error -->
+        <base-alert
+          :variable="unexpectedError"
+          :alert-name="'unexpectedError'"
+          :success="false"
+          @closeAlert="closeAlert"
+        />
+        <div class="w-full px-3 py-3">
           <label
             class="block text-gray-700 text-sm font-bold mb-2"
             for="ingredient-name"
@@ -44,6 +51,9 @@
               </span>
             </div>
           </div>
+          <base-error-paragraph
+            :msg-error="errors.query"
+          />
         </div>
       </div>
     </div>
@@ -101,6 +111,7 @@
 
 <script>
 import { searchCornershopIngredients } from '../../api/ingredients';
+import { requiredField } from '../../utils/validations.js';
 import MarketIngredient from './market-ingredient.vue';
 
 export default {
@@ -108,8 +119,8 @@ export default {
     return {
       scraperProblems: null,
       loading: false,
-      status: null,
-      error: '',
+      unexpectedError: true,
+      errors: { query: '' },
       query: '',
       productsByMarket: [],
       market: null,
@@ -119,19 +130,25 @@ export default {
     MarketIngredient,
   },
   methods: {
+    closeAlert() {
+      this.unexpectedError = false;
+    },
+
     async searchIngredients() {
-      this.loading = true;
-      try {
-        const {
-          data,
-        } = await searchCornershopIngredients(this.query);
-        this.productsByMarket = data.data;
-        this.market = 0;
-        this.scraperProblems = data.message;
-      } catch (error) {
-        this.errorResponse(error);
-      } finally {
-        this.loading = false;
+      if (this.validations()) {
+        this.loading = true;
+        try {
+          const {
+            data,
+          } = await searchCornershopIngredients(this.query);
+          this.productsByMarket = data.data;
+          this.market = 0;
+          this.scraperProblems = data.message;
+        } catch (error) {
+          this.unexpectedError = true;
+        } finally {
+          this.loading = false;
+        }
       }
     },
     addMarketIngredient(productIdx) {
@@ -147,9 +164,12 @@ export default {
       };
       this.$emit('submit', productForm);
     },
-    async errorResponse(error) {
-      this.status = error.response.status;
-      this.error = error;
+
+    validations() {
+      this.errors = { query: '' };
+      this.errors.query = requiredField(this.query, this.errors.query);
+
+      return !(Object.values(this.errors).some(value => !!value));
     },
   },
   computed: {

--- a/app/javascript/components/menus/edit/edit-menu-container.vue
+++ b/app/javascript/components/menus/edit/edit-menu-container.vue
@@ -342,16 +342,14 @@ export default {
       });
     },
 
-    // eslint-disable-next-line max-statements,complexity
     validations() {
       this.errors = { name: '', portions: '' };
 
       this.errors.portions = intNonZero(this.menuPortions, this.errors.portions);
       this.errors.name = requiredField(this.menuName, this.errors.name);
       this.errors.portions = requiredField(this.menuPortions, this.errors.portions);
-      const validForm = !(Object.values(this.errors).some(value => !!value));
 
-      return validForm;
+      return !(Object.values(this.errors).some(value => !!value));
     },
   },
 };

--- a/app/javascript/components/menus/edit/edit-menu-container.vue
+++ b/app/javascript/components/menus/edit/edit-menu-container.vue
@@ -15,24 +15,13 @@
       </div>
     </div>
 
-    <!-- Alert -->
-    <div
-      v-if="error"
-      class="mt-4 w-max bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded relative"
-      role="alert"
-    >
-      <span class="mr-7 block sm:inline">{{ $t('msg.unexpectedError') }}</span>
-      <span
-        class="absolute top-0 bottom-0 right-0 px-4 py-3 cursor-pointer"
-        @click="closeAlert"
-      >
-        <img
-          svg-inline
-          src="../../../../assets/images/cancel-red-svg.svg"
-          class="h-5 w-5 text-red-700"
-        >
-      </span>
-    </div>
+    <!-- Alert unexpected error -->
+    <base-alert
+      :variable="error"
+      :alert-name="'unexpectedError'"
+      :success="false"
+      @closeAlert="closeAlert"
+    />
 
     <div class="flex flex-col py-8 px-6 w-auto h-auto bg-gray-50 flex-grow-0 my-10">
       <div class="flex flex-row">
@@ -45,12 +34,9 @@
             class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
             v-model="menuName"
           >
-          <p
-            v-if="errors.name"
-            class="mt-2 ml-1 text-xs text-red-400"
-          >
-            {{ $t(`msg.${errors.name}`) }}
-          </p>
+          <base-error-paragraph
+            :msg-error="errors.name"
+          />
         </div>
         <!-- Menu Portions -->
         <div class="relative w-2/5 ml-4">
@@ -61,12 +47,9 @@
             class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
             v-model="menuPortions"
           >
-          <p
-            v-if="errors.portions"
-            class="mt-2 ml-1 text-xs text-red-400"
-          >
-            {{ $t(`msg.${errors.portions}`) }}
-          </p>
+          <base-error-paragraph
+            :msg-error="errors.portions"
+          />
         </div>
       </div>
       <!-- Recipes -->
@@ -182,7 +165,7 @@
 <script>
 import { getRecipes } from '../../../api/recipes.js';
 import { getMenu, updateMenu } from '../../../api/menus.js';
-import { intGeqZero, requiredField } from '../../../utils/validations.js';
+import { intNonZero, requiredField } from '../../../utils/validations.js';
 import SelectedRecipesCard from '../base/selected-recipes-card.vue';
 import AddRecipeCard from '../base/add-recipe-card';
 import { getPriceOfSelectedIngredient } from '../../../utils/recipeUtils';
@@ -363,7 +346,7 @@ export default {
     validations() {
       this.errors = { name: '', portions: '' };
 
-      this.errors.portions = intGeqZero(this.menuPortions, this.errors.portions);
+      this.errors.portions = intNonZero(this.menuPortions, this.errors.portions);
       this.errors.name = requiredField(this.menuName, this.errors.name);
       this.errors.portions = requiredField(this.menuPortions, this.errors.portions);
       const validForm = !(Object.values(this.errors).some(value => !!value));

--- a/app/javascript/components/menus/new/new-menu-container.vue
+++ b/app/javascript/components/menus/new/new-menu-container.vue
@@ -279,7 +279,6 @@ export default {
       this.error = false;
     },
 
-    // eslint-disable-next-line max-statements,complexity
     validations() {
       this.errors = { name: '', portions: '' };
 
@@ -287,9 +286,7 @@ export default {
       this.errors.name = requiredField(this.menuName, this.errors.name);
       this.errors.portions = requiredField(this.menuPortions, this.errors.portions);
 
-      const validForm = !(Object.values(this.errors).some(value => !!value));
-
-      return validForm;
+      return !(Object.values(this.errors).some(value => !!value));
     },
   },
 };

--- a/app/javascript/components/menus/new/new-menu-container.vue
+++ b/app/javascript/components/menus/new/new-menu-container.vue
@@ -15,24 +15,13 @@
       </div>
     </div>
 
-    <!-- Alert -->
-    <div
-      v-if="error"
-      class="mt-4 w-max bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded relative"
-      role="alert"
-    >
-      <span class="mr-7 block sm:inline">{{ $t('msg.unexpectedError') }}</span>
-      <span
-        class="absolute top-0 bottom-0 right-0 px-4 py-3 cursor-pointer"
-        @click="closeAlert"
-      >
-        <img
-          svg-inline
-          src="../../../../assets/images/cancel-red-svg.svg"
-          class="h-5 w-5 text-red-700"
-        >
-      </span>
-    </div>
+    <!-- Alert unexpected error -->
+    <base-alert
+      :variable="error"
+      :alert-name="'unexpectedError'"
+      :success="false"
+      @closeAlert="closeAlert"
+    />
 
     <div class="flex flex-col py-8 px-6 w-auto h-auto bg-gray-50 flex-grow-0 my-10">
       <!-- Menu Name -->
@@ -45,12 +34,9 @@
             class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
             v-model="menuName"
           >
-          <p
-            v-if="errors.name"
-            class="mt-2 ml-1 text-xs text-red-400"
-          >
-            {{ $t(`msg.${errors.name}`) }}
-          </p>
+          <base-error-paragraph
+            :msg-error="errors.name"
+          />
         </div>
         <!-- Menu Portions -->
         <div class="relative w-2/5 ml-4">
@@ -61,12 +47,9 @@
             class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
             v-model="menuPortions"
           >
-          <p
-            v-if="errors.portions"
-            class="mt-2 ml-1 text-xs text-red-400"
-          >
-            {{ $t(`msg.${errors.portions}`) }}
-          </p>
+          <base-error-paragraph
+            :msg-error="errors.portions"
+          />
         </div>
       </div>
       <!-- Recipes -->
@@ -182,7 +165,7 @@
 <script>
 import { getRecipes } from '../../../api/recipes.js';
 import { postMenu } from '../../../api/menus.js';
-import { intGeqZero, requiredField } from '../../../utils/validations.js';
+import { intNonZero, requiredField } from '../../../utils/validations.js';
 import SelectedRecipesCard from '../base/selected-recipes-card.vue';
 import AddRecipeCard from '../base/add-recipe-card';
 import { getPriceOfSelectedIngredient } from '../../../utils/recipeUtils';
@@ -300,7 +283,7 @@ export default {
     validations() {
       this.errors = { name: '', portions: '' };
 
-      this.errors.portions = intGeqZero(this.menuPortions, this.errors.portions);
+      this.errors.portions = intNonZero(this.menuPortions, this.errors.portions);
       this.errors.name = requiredField(this.menuName, this.errors.name);
       this.errors.portions = requiredField(this.menuPortions, this.errors.portions);
 

--- a/app/javascript/components/recipes/edit/recipe-edit.vue
+++ b/app/javascript/components/recipes/edit/recipe-edit.vue
@@ -154,7 +154,6 @@ export default {
     try {
       const response = await getRecipe(this.recipeId);
       this.recipe = { id: response.data.data.id, ...response.data.data.attributes };
-      this.status = status;
     } catch (error) {
       this.unexpectedError = true;
     } finally {
@@ -290,7 +289,6 @@ export default {
       }
     },
 
-    // eslint-disable-next-line max-statements,complexity
     validations() {
       this.errors = { name: '', portions: '', cookMinutes: '' };
 
@@ -299,9 +297,8 @@ export default {
       this.errors.name = requiredField(this.recipe.name, this.errors.name);
       this.errors.portions = requiredField(this.recipe.portions, this.errors.portions);
       this.errors.cookMinutes = requiredField(this.recipe.cookMinutes, this.errors.cookMinutes);
-      const validForm = !(Object.values(this.errors).some(value => !!value));
 
-      return validForm;
+      return !(Object.values(this.errors).some(value => !!value));
     },
 
   },

--- a/app/javascript/components/recipes/edit/recipe-edit.vue
+++ b/app/javascript/components/recipes/edit/recipe-edit.vue
@@ -14,24 +14,13 @@
       </div>
     </div>
 
-    <!-- Alert -->
-    <div
-      v-if="error"
-      class="mt-4 w-max bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded relative"
-      role="alert"
-    >
-      <span class="mr-7 block sm:inline">{{ $t('msg.unexpectedError') }}</span>
-      <span
-        class="absolute top-0 bottom-0 right-0 px-4 py-3 cursor-pointer"
-        @click="closeAlert"
-      >
-        <img
-          svg-inline
-          src="../../../../assets/images/cancel-red-svg.svg"
-          class="h-5 w-5 text-red-700"
-        >
-      </span>
-    </div>
+    <!-- Alert unexpected error -->
+    <base-alert
+      :variable="unexpectedError"
+      :alert-name="'unexpectedError'"
+      :success="false"
+      @closeAlert="closeAlert"
+    />
 
     <div
       v-if="!loading"
@@ -53,12 +42,9 @@
               class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
               v-model="recipe.name"
             >
-            <p
-              v-if="errors.name"
-              class="mt-2 ml-1 text-xs text-red-400"
-            >
-              {{ $t(`msg.${errors.name}`) }}
-            </p>
+            <base-error-paragraph
+              :msg-error="errors.name"
+            />
           </div>
           <div class="relative w-1/4">
             <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-2">
@@ -68,12 +54,9 @@
               class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
               v-model="recipe.portions"
             >
-            <p
-              v-if="errors.portions"
-              class="mt-2 ml-1 text-xs text-red-400"
-            >
-              {{ $t(`msg.${errors.portions}`) }}
-            </p>
+            <base-error-paragraph
+              :msg-error="errors.portions"
+            />
           </div>
           <div class="relative w-1/4">
             <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-2">
@@ -83,12 +66,9 @@
               class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
               v-model="recipe.cookMinutes"
             >
-            <p
-              v-if="errors.cookMinutes"
-              class="mt-2 ml-1 text-xs text-red-400"
-            >
-              {{ $t(`msg.${errors.cookMinutes}`) }}
-            </p>
+            <base-error-paragraph
+              :msg-error="errors.cookMinutes"
+            />
           </div>
         </div>
       </div>
@@ -140,7 +120,7 @@
 
 <script>
 import { getRecipe, updateRecipe } from '../../../api/recipes.js';
-import { geqZero, intGeqZero, requiredField } from '../../../utils/validations.js';
+import { geqZero, intNonZero, requiredField } from '../../../utils/validations.js';
 import recipeIngredients from '../base/recipe-ingredients.vue';
 import recipeSteps from '../base/recipe-steps.vue';
 
@@ -155,8 +135,7 @@ export default {
   data() {
     return {
       loading: false,
-      status: '',
-      error: false,
+      unexpectedError: false,
       recipe: {
         id: null,
         name: '',
@@ -177,14 +156,14 @@ export default {
       this.recipe = { id: response.data.data.id, ...response.data.data.attributes };
       this.status = status;
     } catch (error) {
-      this.error = true;
+      this.unexpectedError = true;
     } finally {
       this.loading = false;
     }
   },
   methods: {
     closeAlert() {
-      this.error = false;
+      this.unexpectedError = false;
     },
     cancelEdit() {
       window.location = `/recipes/${this.recipeId}`;
@@ -197,7 +176,7 @@ export default {
           await updateRecipe(this.recipe.id, updatedRecipe);
           window.location = `/recipes/${this.recipeId}`;
         } catch (error) {
-          this.error = true;
+          this.unexpectedError = true;
         } finally {
           this.loading = false;
         }
@@ -315,7 +294,7 @@ export default {
     validations() {
       this.errors = { name: '', portions: '', cookMinutes: '' };
 
-      this.errors.portions = intGeqZero(this.recipe.portions, this.errors.portions);
+      this.errors.portions = intNonZero(this.recipe.portions, this.errors.portions);
       this.errors.cookMinutes = geqZero(this.recipe.cookMinutes, this.errors.cookMinutes);
       this.errors.name = requiredField(this.recipe.name, this.errors.name);
       this.errors.portions = requiredField(this.recipe.portions, this.errors.portions);

--- a/app/javascript/components/recipes/index/filter-popup-content.vue
+++ b/app/javascript/components/recipes/index/filter-popup-content.vue
@@ -14,6 +14,9 @@
           :placeholder="$t('msg.min')"
           v-model="filters.price.min"
         >
+        <base-error-paragraph
+          :msg-error="errors.priceMin"
+        />
       </div>
       <div class="ml-2">
         <p>
@@ -24,6 +27,9 @@
           :placeholder="$t('msg.max')"
           v-model="filters.price.max"
         >
+        <base-error-paragraph
+          :msg-error="errors.priceMax"
+        />
       </div>
     </div>
 
@@ -41,6 +47,9 @@
           :placeholder="$t('msg.min')"
           v-model="filters.portions.min"
         >
+        <base-error-paragraph
+          :msg-error="errors.portionsMin"
+        />
       </div>
       <div class="ml-2">
         <p>
@@ -51,6 +60,9 @@
           :placeholder="$t('msg.max')"
           v-model="filters.portions.max"
         >
+        <base-error-paragraph
+          :msg-error="errors.portionsMax"
+        />
       </div>
     </div>
   </div>
@@ -61,6 +73,7 @@
 export default {
   props: {
     actualfilters: { type: Object, required: true },
+    errors: { type: Object, required: true },
   },
   data() {
     return {

--- a/app/javascript/components/recipes/index/recipes-container.vue
+++ b/app/javascript/components/recipes/index/recipes-container.vue
@@ -82,6 +82,7 @@
       <filter-popup-content
         ref="filtersInfo"
         :actualfilters="filters"
+        :errors="filterErrors"
       />
     </base-modal>
   </div>
@@ -90,6 +91,7 @@
 <script>
 
 import { getRecipes } from '../../../api/recipes.js';
+import { intGeqZero } from '../../../utils/validations.js';
 import Filters from './filters';
 import FilterPopupContent from './filter-popup-content';
 import RecipesPagination from './pagination/recipes-pagination';
@@ -114,6 +116,7 @@ export default {
       filterOptions: ['price', 'portions'],
       error: '',
       showingFiltersModal: false,
+      filterErrors: { priceMin: '', priceMax: '', portionsMin: '', portionsMax: '' },
     };
   },
   async created() {
@@ -209,8 +212,20 @@ export default {
       this.filters.portions.max = '';
     },
     updateFilters() {
-      this.showingFiltersModal = !this.showingFiltersModal;
-      this.filters = this.$refs.filtersInfo.filters;
+      if (this.filterValidations()) {
+        this.showingFiltersModal = !this.showingFiltersModal;
+        this.filters = this.$refs.filtersInfo.filters;
+      }
+    },
+    filterValidations() {
+      this.filterErrors = { priceMin: '', priceMax: '', portionsMin: '', portionsMax: '' };
+      const form = this.$refs.filtersInfo.filters;
+      this.filterErrors.priceMin = intGeqZero(form.price.min, this.filterErrors.priceMin);
+      this.filterErrors.priceMax = intGeqZero(form.price.max, this.filterErrors.priceMax);
+      this.filterErrors.portionsMin = intGeqZero(form.portions.min, this.filterErrors.portionsMin);
+      this.filterErrors.portionsMax = intGeqZero(form.portions.max, this.filterErrors.portionsMax);
+
+      return !(Object.values(this.filterErrors).some(value => !!value));
     },
   },
 };

--- a/app/javascript/components/recipes/new/recipe-create.vue
+++ b/app/javascript/components/recipes/new/recipe-create.vue
@@ -282,7 +282,6 @@ export default {
       }
     },
 
-    // eslint-disable-next-line max-statements,complexity
     validations() {
       this.errors = { name: '', portions: '', cookMinutes: '' };
 
@@ -292,9 +291,7 @@ export default {
       this.errors.portions = requiredField(this.recipe.portions, this.errors.portions);
       this.errors.cookMinutes = requiredField(this.recipe.cookMinutes, this.errors.cookMinutes);
 
-      const validForm = !(Object.values(this.errors).some(value => !!value));
-
-      return validForm;
+      return !(Object.values(this.errors).some(value => !!value));
     },
   },
 };

--- a/app/javascript/components/recipes/new/recipe-create.vue
+++ b/app/javascript/components/recipes/new/recipe-create.vue
@@ -20,24 +20,13 @@
       </span>
     </div>
 
-    <!-- Alert -->
-    <div
-      v-if="error"
-      class="mt-4 w-max bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded relative"
-      role="alert"
-    >
-      <span class="mr-7 block sm:inline">{{ $t('msg.unexpectedError') }}</span>
-      <span
-        class="absolute top-0 bottom-0 right-0 px-4 py-3 cursor-pointer"
-        @click="closeAlert"
-      >
-        <img
-          svg-inline
-          src="../../../../assets/images/cancel-red-svg.svg"
-          class="h-5 w-5 text-red-700"
-        >
-      </span>
-    </div>
+    <!-- Alert unexpected error -->
+    <base-alert
+      :variable="unexpectedError"
+      :alert-name="'unexpectedError'"
+      :success="false"
+      @closeAlert="closeAlert"
+    />
 
     <div
       v-if="!loading"
@@ -59,12 +48,9 @@
               class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
               v-model="recipe.name"
             >
-            <p
-              v-if="errors.name"
-              class="mt-2 ml-1 text-xs text-red-400"
-            >
-              {{ $t(`msg.${errors.name}`) }}
-            </p>
+            <base-error-paragraph
+              :msg-error="errors.name"
+            />
           </div>
           <div class="relative w-1/4">
             <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-2">
@@ -74,12 +60,9 @@
               class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
               v-model="recipe.portions"
             >
-            <p
-              v-if="errors.portions"
-              class="mt-2 ml-1 text-xs text-red-400"
-            >
-              {{ $t(`msg.${errors.portions}`) }}
-            </p>
+            <base-error-paragraph
+              :msg-error="errors.portions"
+            />
           </div>
           <div class="relative w-1/4">
             <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-2">
@@ -89,12 +72,9 @@
               class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
               v-model="recipe.cookMinutes"
             >
-            <p
-              v-if="errors.cookMinutes"
-              class="mt-2 ml-1 text-xs text-red-400"
-            >
-              {{ $t(`msg.${errors.cookMinutes}`) }}
-            </p>
+            <base-error-paragraph
+              :msg-error="errors.cookMinutes"
+            />
           </div>
         </div>
       </div>
@@ -146,7 +126,7 @@
 
 <script>
 import { postRecipe } from '../../../api/recipes.js';
-import { geqZero, intGeqZero, requiredField } from '../../../utils/validations.js';
+import { geqZero, intNonZero, requiredField } from '../../../utils/validations.js';
 import recipeIngredients from '../base/recipe-ingredients.vue';
 import recipeSteps from '../base/recipe-steps.vue';
 
@@ -158,8 +138,7 @@ export default {
   data() {
     return {
       loading: false,
-      status: '',
-      error: false,
+      unexpectedError: false,
       recipe: {
         id: null,
         name: '',
@@ -175,7 +154,7 @@ export default {
   },
   methods: {
     closeAlert() {
-      this.error = false;
+      this.unexpectedError = false;
     },
     cancelCreate() {
       window.location = '/recipes';
@@ -189,7 +168,7 @@ export default {
           await postRecipe(recipeToCreate);
           window.location = '/recipes';
         } catch (error) {
-          this.error = true;
+          this.unexpectedError = true;
         } finally {
           this.loading = false;
         }
@@ -307,7 +286,7 @@ export default {
     validations() {
       this.errors = { name: '', portions: '', cookMinutes: '' };
 
-      this.errors.portions = intGeqZero(this.recipe.portions, this.errors.portions);
+      this.errors.portions = intNonZero(this.recipe.portions, this.errors.portions);
       this.errors.cookMinutes = geqZero(this.recipe.cookMinutes, this.errors.cookMinutes);
       this.errors.name = requiredField(this.recipe.name, this.errors.name);
       this.errors.portions = requiredField(this.recipe.portions, this.errors.portions);

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -77,9 +77,6 @@ export default {
       defaultUnit: 'Unidad por defecto',
       alternativeUnit: 'Unidades alternativas',
       addUnit: 'Agregar Unidad',
-      msjAlert: 'Debe ingresar el nombre, la cantidad y la unidad',
-      msjMinQuantity: 'El inventario debe ser mayor o igual a 1',
-      msjNegativeQuantity: 'La cantidad mínima debe ser mayor o igual a 0',
       associationWarning: 'Este ingrediente se encuentra en la(s) siguiente(s) receta(s):',
       newMeasure: 'Crear la medida',
       inventory: {

--- a/app/javascript/utils/validations.js
+++ b/app/javascript/utils/validations.js
@@ -10,6 +10,14 @@ function intGeqZero(field, initialError) {
 
   return error;
 }
+
+function intNonZero(field, initialError) {
+  let error = initialError;
+  if (field && (!(Number.isInteger(field - 0)) || !(field > 0))) error = 'intNonZero';
+
+  return error;
+}
+
 function requiredField(field, initialError) {
   let error = initialError;
   if (!field) error = 'requiredField';
@@ -29,4 +37,4 @@ function validEmail(field, initialError) {
   return error;
 }
 
-export { geqZero, intGeqZero, requiredField, validEmail };
+export { geqZero, intGeqZero, intNonZero, requiredField, validEmail };

--- a/app/javascript/utils/validations.js
+++ b/app/javascript/utils/validations.js
@@ -4,6 +4,14 @@ function geqZero(field, initialError) {
 
   return error;
 }
+
+function floatNonZero(field, initialError) {
+  let error = initialError;
+  if (field && ((typeof (field - 0) === 'number') || !(field > 0))) error = 'floatNonZero';
+
+  return error;
+}
+
 function intGeqZero(field, initialError) {
   let error = initialError;
   if (field && (!(Number.isInteger(field - 0)) || !(field >= 0))) error = 'intGeqZero';
@@ -37,4 +45,4 @@ function validEmail(field, initialError) {
   return error;
 }
 
-export { geqZero, intGeqZero, intNonZero, requiredField, validEmail };
+export { geqZero, floatNonZero, intGeqZero, intNonZero, requiredField, validEmail };

--- a/app/javascript/utils/validations.js
+++ b/app/javascript/utils/validations.js
@@ -7,7 +7,7 @@ function geqZero(field, initialError) {
 
 function floatNonZero(field, initialError) {
   let error = initialError;
-  if (field && ((typeof (field - 0) === 'number') || !(field > 0))) error = 'floatNonZero';
+  if (field && (!(typeof (field - 0) === 'number') || !(field > 0))) error = 'floatNonZero';
 
   return error;
 }


### PR DESCRIPTION
BASE #169 

# Lo que hice

Refactor de validaciones para ingredientes, recetas y menú, usando componentes para alertas, párrafos de error y usando las funciones de validación que se encuentran en `utils`.

# QA

Dar una repasada a lo siguiente y corroborar que esté siga funcionando (probar con diferentes inputs: negativos, cero, decimales, enteros, dejar en blanco, mails no válidos, letras en algún input que debería ser número, agregar algo con un nombre de algo que ya existe y **ver que los errores mostrados tienen sentido**. No debería aparecer ninguna alerta del navegador):

- Form de agregar ingrediente
- Form de editar ingrediente
- Form de editar ingrediente cuando se busca en supermercado
- Crear receta
- Editar receta
- Crear menú
- Editar menú

