### PR TITLE
Details

### DIFF
--- a/app/assets/images/chevron-up-svg.svg
+++ b/app/assets/images/chevron-up-svg.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+</svg>

--- a/app/javascript/components/ingredients/ingredients-form.vue
+++ b/app/javascript/components/ingredients/ingredients-form.vue
@@ -251,7 +251,7 @@ export default {
         Litro: { Mililitro: 0.001 },
         Mililitro: { Litro: 1000 },
         Taza: { Cucharada: 0.0625, Cucharadita: 0.020833 },
-        Cucharada: { Cucharadita: 0.333, Taza: 16 },
+        Cucharada: { Cucharadita: 0.333333333, Taza: 16 },
         Cucharadita: { Taza: 48, Cucharada: 3 },
       },
       showingMeasureModal: false,

--- a/app/javascript/components/layout/top-navbar.vue
+++ b/app/javascript/components/layout/top-navbar.vue
@@ -62,29 +62,29 @@
         <base-spinner />
       </div>
       <div
-        class="flex justify-between my-1 p-2 px-4 w-96 text-lg font-medium"
+        class="flex justify-between my-1 p-2 px-4 w-auto text-lg font-medium"
         v-if="!this.alertLoading"
       >
         {{ $t('msg.ingredients.alertIngredients') }}:
       </div>
       <div
-        class="flex justify-between my-1 p-2 px-4 bg-gray-100 w-96"
+        class="flex justify-between my-1 p-2 px-4 bg-gray-100 w-auto"
         v-if="alertIngredients.length == 0 && !this.alertLoading"
       >
         {{ $t('msg.ingredients.noAlert') }}
       </div>
       <div
-        class="flex justify-between my-1 p-2 px-4 bg-red-100 w-96"
+        class="flex justify-between my-1 p-2 px-4 bg-red-100 w-auto"
         v-for="ingredient in alertIngredients"
         :key="ingredient.id"
       >
         <div>
           {{ ingredient.name }}
         </div>
-        <div class="flex">
-          <div class="text-red-600">
-            {{ ingredient.inventory }}
-          </div>/{{ ingredient.minimumQuantity }} {{ ingredient.measure }}
+        <div class="flex px-3">
+          <div class="text-red-600 px-1">
+            {{ ingredient.inventory }} {{ ingredient.measure }}
+          </div>(Mínimo {{ ingredient.minimumQuantity }} {{ ingredient.measure }})
         </div>
       </div>
     </base-modal>

--- a/app/javascript/components/menus/index/menu-shopping-list.vue
+++ b/app/javascript/components/menus/index/menu-shopping-list.vue
@@ -101,8 +101,9 @@ export default {
       this.loading = false;
     },
     formatIngredientInfo(ingredient) {
-      // eslint-disable-next-line no-magic-numbers
-      return `${ingredient.name}, ${Math.round(ingredient.quantity * 100) / 100}
+      const number = 100;
+
+      return `${ingredient.name}, ${Math.round(ingredient.quantity * number) / number}
       ${ingredient.measure}, $ ${Math.round(ingredient.totalPrice)}`;
     },
     async downloadShoppingList() {

--- a/app/javascript/components/menus/index/menu-shopping-list.vue
+++ b/app/javascript/components/menus/index/menu-shopping-list.vue
@@ -101,7 +101,9 @@ export default {
       this.loading = false;
     },
     formatIngredientInfo(ingredient) {
-      return `${ingredient.name}, ${ingredient.quantity} ${ingredient.measure}, $ ${ingredient.totalPrice}`;
+      // eslint-disable-next-line no-magic-numbers
+      return `${ingredient.name}, ${Math.round(ingredient.quantity * 100) / 100}
+      ${ingredient.measure}, $ ${Math.round(ingredient.totalPrice)}`;
     },
     async downloadShoppingList() {
       downloadShoppingList(this.menuId);

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -165,9 +165,14 @@
             </div>
           </div>
           <br>
-          <p class="text-md font-bold">
-            Ingredientes con falta de inventario
-          </p>
+          <div class="flex">
+            <p class="text-md font-bold">
+              Ingredientes con falta de inventario
+            </p>
+            <p class="px-1">
+              (Si reduces, quedaran en 0)
+            </p>
+          </div>
           <div
             v-for="(messages, index) in listOfMessagesToConfirmWithoutInventory"
             :key="`toReduce${index}`"
@@ -260,8 +265,8 @@ export default {
         obj.ingredients.map((element) =>
           `Has reducido ${Math.round(element.quantity * this.numberToGetDecimals) / this.numberToGetDecimals}
           ${element.measure} de <strong>${element.name} </strong> y quedaste en <strong> 
-          ${Math.round(element.inventory * this.numberToGetDecimals) / this.numberToGetDecimals} </strong>
-          ${element.measure}`,
+          ${Math.round(element.inventory * this.numberToGetDecimals) / this.numberToGetDecimals} 
+          ${element.measure} </strong>`,
         ));
 
       return listOfMessages;

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 /* eslint-disable array-callback-return */
 /* eslint-disable consistent-return */
 /* eslint-disable consistent-return */
@@ -158,7 +159,9 @@
               v-for="(message, msg_idx) in messages"
               :key="msg_idx"
             >
-              <p>{{ message }}</p>
+              <p>
+                {{ message }}
+              </p>
             </div>
           </div>
           <br>
@@ -173,7 +176,9 @@
               v-for="(message, msg_idx) in messages"
               :key="`toReduce${msg_idx}`"
             >
-              <p>{{ message }}</p>
+              <p>
+                {{ message }}
+              </p>
             </div>
           </div>
         </div>
@@ -199,7 +204,9 @@
             v-for="(message, msg_idx) in messages"
             :key="msg_idx"
           >
-            <p>{{ message }}</p>
+            <p v-html="message">
+              {{ message }}
+            </p>
           </div>
         </div>
       </base-modal>
@@ -226,6 +233,7 @@ export default {
       showingReduceMsg: false,
       showReductionOfInventory: false,
       loading: true,
+      numberToGetDecimals: 100,
     };
   },
   props: {
@@ -250,8 +258,10 @@ export default {
     getMessageofReduction(menuIngredients) {
       const listOfMessages = menuIngredients.map((obj) =>
         obj.ingredients.map((element) =>
-          `Has reducido ${element.quantity} ${element.measure} de ${element.name} y quedaste en ${element.inventory}
-           ${element.measure}`,
+          `Has reducido ${Math.round(element.quantity * this.numberToGetDecimals) / this.numberToGetDecimals}
+          ${element.measure} de <strong>${element.name} </strong> y quedaste en <strong> 
+          ${Math.round(element.inventory * this.numberToGetDecimals) / this.numberToGetDecimals} </strong>
+          ${element.measure}`,
         ));
 
       return listOfMessages;
@@ -260,9 +270,12 @@ export default {
     getMessageConfirmationElementsWithInventory(menuIngredients) {
       const listOfMessagesWithInventory = menuIngredients.map((obj) =>
         obj.ingredients.map((element) => {
-          const nuevoInventario = element.inventory - element.quantity;
+          // eslint-disable-next-line no-magic-numbers
+          let nuevoInventario = (element.inventory - element.quantity).toFixed(this.numberDecimals);
+          nuevoInventario = Math.round(nuevoInventario * this.numberToGetDecimals) / this.numberToGetDecimals;
           if (nuevoInventario >= 0) {
-            return ` ${element.name}: de ${element.inventory} a ${nuevoInventario}  ${element.measure}`;
+            return ` ${element.name}: de ${Math.round(element.inventory * this.numberToGetDecimals) /
+            this.numberToGetDecimals} a ${nuevoInventario} ${element.measure}`;
           }
 
           return '';
@@ -276,8 +289,9 @@ export default {
         obj.ingredients.map((element) => {
           const nuevoInventario = element.inventory - element.quantity;
           if (nuevoInventario < 0) {
-            return ` ${element.name}: ${element.quantity} ${element.measure} (Tienes ${element.inventory}
-            ${element.measure})`;
+            return `${element.name}: ${Math.round(element.quantity * this.numberToGetDecimals) /
+            this.numberToGetDecimals} ${element.measure} (Tienes ${Math.round(element.inventory *
+            this.numberToGetDecimals) / this.numberToGetDecimals} ${element.measure})`;
           }
 
           return '';
@@ -291,14 +305,14 @@ export default {
     },
 
     async toggleReduce(menuId) {
-      this.showingReduceMsg = !this.showingReduceMsg;
       this.idMenuToReduce = menuId;
       const menuIngredientsResponse = await getShoppingList(menuId);
-      this.menuIngredients = menuIngredientsResponse.data;
+      const menuIngredients = menuIngredientsResponse.data;
       this.listOfMessagesToConfirmWithInventory =
-      this.getMessageConfirmationElementsWithInventory(this.menuIngredients);
+      this.getMessageConfirmationElementsWithInventory(menuIngredients);
       this.listOfMessagesToConfirmWithoutInventory =
-      this.getMessageConfirmationElementsWithoutInventory(this.menuIngredients);
+      this.getMessageConfirmationElementsWithoutInventory(menuIngredients);
+      this.showingReduceMsg = !this.showingReduceMsg;
 
       this.loading = false;
     },

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -321,7 +321,6 @@ export default {
       this.getMessageConfirmationElementsWithInventory(menuIngredients);
       this.listOfMessagesToConfirmWithoutInventory =
       this.getMessageConfirmationElementsWithoutInventory(menuIngredients);
-      console.log(this.listOfMessagesToConfirmWithoutInventory);
 
       this.showingReduceMsg = !this.showingReduceMsg;
 

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -1,8 +1,3 @@
-/* eslint-disable no-magic-numbers */
-/* eslint-disable array-callback-return */
-/* eslint-disable consistent-return */
-/* eslint-disable consistent-return */
-/* eslint-disable consistent-return */
 <template>
   <div class="w-full">
     <table class="w-full divide-y divide-gray-200">
@@ -169,9 +164,15 @@
             <p class="text-md font-bold">
               Ingredientes con falta de inventario
             </p>
-            <p class="px-1">
-              (Si reduces, quedaran en 0)
-            </p>
+            <div
+              v-if="anyElementWithoutInventory"
+            >
+              <p
+                class="px-1"
+              >
+                (Si reduces, quedaran en 0)
+              </p>
+            </div>
           </div>
           <div
             v-for="(messages, index) in listOfMessagesToConfirmWithoutInventory"
@@ -253,7 +254,7 @@ export default {
         this.error = error;
       }
       const menuIngredientsResponse = await getShoppingList(this.idMenuToReduce);
-      this.menuIngredients = menuIngredientsResponse.data; // Quizas estas lineas sobran. REV
+      this.menuIngredients = menuIngredientsResponse.data;
       this.toggleMessageReduction();
     },
     toggleMessageReduction() {
@@ -290,10 +291,13 @@ export default {
       return listOfMessagesWithInventory;
     },
     getMessageConfirmationElementsWithoutInventory(menuIngredients) {
+      this.anyElementWithoutInventory = false;
       const listOfMessagesWithoutInventory = menuIngredients.map((obj) =>
         obj.ingredients.map((element) => {
           const nuevoInventario = element.inventory - element.quantity;
           if (nuevoInventario < 0) {
+            this.anyElementWithoutInventory = true;
+
             return `${element.name}: ${Math.round(element.quantity * this.numberToGetDecimals) /
             this.numberToGetDecimals} ${element.measure} (Tienes ${Math.round(element.inventory *
             this.numberToGetDecimals) / this.numberToGetDecimals} ${element.measure})`;
@@ -317,6 +321,8 @@ export default {
       this.getMessageConfirmationElementsWithInventory(menuIngredients);
       this.listOfMessagesToConfirmWithoutInventory =
       this.getMessageConfirmationElementsWithoutInventory(menuIngredients);
+      console.log(this.listOfMessagesToConfirmWithoutInventory);
+
       this.showingReduceMsg = !this.showingReduceMsg;
 
       this.loading = false;

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -276,7 +276,6 @@ export default {
     getMessageConfirmationElementsWithInventory(menuIngredients) {
       const listOfMessagesWithInventory = menuIngredients.map((obj) =>
         obj.ingredients.map((element) => {
-          // eslint-disable-next-line no-magic-numbers
           let nuevoInventario = (element.inventory - element.quantity).toFixed(this.numberDecimals);
           nuevoInventario = Math.round(nuevoInventario * this.numberToGetDecimals) / this.numberToGetDecimals;
           if (nuevoInventario >= 0) {

--- a/app/javascript/components/providers/index/provider-index-component.vue
+++ b/app/javascript/components/providers/index/provider-index-component.vue
@@ -44,7 +44,7 @@
       </div>
       <!-- proovedores -->
       <div
-        class="flex w-full flex-wrap justify-between bg-gray-50"
+        class="flex w-full flex-wrap justify-between bg-gray-50 px-20"
       >
         <p
           v-if="this.providers.length===0 && !loading"

--- a/app/javascript/components/providers/index/provider-item.vue
+++ b/app/javascript/components/providers/index/provider-item.vue
@@ -48,11 +48,24 @@
         class="flex items-center w-6 h-6 self-stretch justify-self-end"
         @click="toggleOpenModal"
       >
-        <img
-          svg-inline
-          src="../../../../assets/images/chevron-down-svg.svg"
-          class="w-6 h-6"
+        <div
+          v-if="showingDetails"
         >
+          <img
+            svg-inline
+            src="../../../../assets/images/chevron-up-svg.svg"
+            class="w-6 h-6 cursor-pointer"
+          >
+        </div>
+        <div
+          v-else
+        >
+          <img
+            svg-inline
+            src="../../../../assets/images/chevron-down-svg.svg"
+            class="w-6 h-6 cursor-pointer"
+          >
+        </div>
       </div>
     </div>
     <div
@@ -154,7 +167,7 @@
       <div class="flex flex-row items-start order-2 self-stretch w-80 justify-between mx-2">
         <div>
           <button
-            class="flex flex-row items-center justify-center bg-green-500 hover:bg-green-700 text-white rounded order-1 flex-grow-1 px-2"
+            class="flex flex-row items-center justify-center border-2 border-red-600 hover:bg-gray-300 text-red-600 rounded order-1 flex-grow-1 px-2"
             @click="toggleDelModal"
           >
             {{ $t('msg.providers.delete') }}
@@ -162,7 +175,7 @@
         </div>
         <div>
           <button
-            class="flex flex-row items-center justify-center bg-white hover:bg-gray-300 text-black rounded order-1 flex-grow-1 px-2"
+            class="flex flex-row items-center justify-center bg-white border-2 border-black hover:bg-gray-300 text-black rounded order-1 flex-grow-1 px-2"
             @click="toggleEditModal"
           >
             {{ $t('msg.providers.edit') }}


### PR DESCRIPTION
### Contexto
Agustín nos comento varios detalles de diseño y usabilidad a mejorar. Tome varios de esos comentarios y fui arreglando cosas chicas. 

### Lo que se hizo
Ingredientes: 
Antes si agregaba 2 cucharas aparecían 6.01 cucharaditas. Ahora mejore esa conversion para que sea mas exacta.

Alertas:
Se cambio el formato de las alertas de fracción a algo del estilo: Arroz  0 Kg (mínimo 2kg)

En Menu: 
El modal de preguntar si estas seguro de reducir? Se cambio por mostrar la información de lo que se esta reduciendo y del inventario actual (Es decir, si se tiene suficiente inventario en cada ingrediente del menu).
Se mejoró el diseño de el modal que muestra cuanto se redujo de cada ingrediente.

En Proveedores:
Que no quede un espacio tan grande al medio entre proveedores 
Al hacer click en el botón de agrandar un proveedor se debería cambiar la dirección del chevron 
El color del botón "Eliminar proveedor" se cambio a rojo 
Se agregó un borde más evidente o algo al botón de Editar proveedor 

PD: Perdón si mezcle cosas nada que ver en la misma PR

### QA
Ir a proveedores y ver como quedaron los cambios de diseño
Ir a menus, reducir el inventario y ver como se muestra la información de los ingredientes a reducir.
Luego de eso, ir a las alertas y ver como cambio el diseño (ya no se muestran en fracción).

Adjunto fotos de como se deberían ver las cosas:
![Captura de pantalla 2021-07-12 a la(s) 11 52 42](https://user-images.githubusercontent.com/48296628/125321594-d9e87380-e30a-11eb-9f97-9b765d0e7678.png)
![Captura de pantalla 2021-07-12 a la(s) 12 15 46](https://user-images.githubusercontent.com/48296628/125321647-ea005300-e30a-11eb-8477-d668b117c888.png)
![Captura de pantalla 2021-07-12 a la(s) 12 16 44](https://user-images.githubusercontent.com/48296628/125321806-1025f300-e30b-11eb-9457-44c9512968d2.png)
![Captura de pantalla 2021-07-12 a la(s) 12 16 39](https://user-images.githubusercontent.com/48296628/125321858-1d42e200-e30b-11eb-881a-da1e1c56c38e.png)

