### PR TITLE
feat(ingredients-pagination): ingredients pagination

### DIFF
--- a/app/assets/images/keyboard-arrow-left-svg.svg
+++ b/app/assets/images/keyboard-arrow-left-svg.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+</svg>

--- a/app/javascript/components/base/base-pagination.vue
+++ b/app/javascript/components/base/base-pagination.vue
@@ -1,10 +1,10 @@
 <template>
   <div
-    class="flex w-90 justify-end m-2"
+    class="flex w-90 justify-center m-2"
     v-if="finalPage != 1"
   >
     <button
-      class="focus:outline-none"
+      class="focus:outline-none m-2"
       v-if="currentPage != 1"
       @click="prev"
     >
@@ -15,7 +15,7 @@
       >
     </button>
     <button
-      class="focus:outline-none disabled:opacity-50 ..."
+      class="focus:outline-none m-2 disabled:opacity-50 ..."
       disabled
       v-else
     >
@@ -26,26 +26,48 @@
       >
     </button>
     <div
-      v-for="index in getShownPages()"
+      v-if="1 < shownPages[0]"
+    >
+      <button
+        class="focus:outline-none w-5 m-2"
+        @click="changePage(1)"
+      >
+        {{ 1 }}
+      </button>
+      ...
+    </div>
+    <div
+      v-for="index in shownPages"
       :key="index"
     >
       <button
-        class="bg-yellow-500 focus:outline-none w-5"
+        class="text-yellow-500 focus:outline-none w-5 m-2"
         v-if="index === currentPage"
         @click="changePage(index)"
       >
         {{ index }}
       </button>
       <button
-        class="focus:outline-none w-5"
+        class="focus:outline-none w-5 m-2"
         v-else
         @click="changePage(index)"
       >
         {{ index }}
       </button>
     </div>
+    <div
+      v-if="finalPage > shownPages[shownPages.length - 1]"
+    >
+      ...
+      <button
+        class="focus:outline-none w-5 m-2"
+        @click="changePage(finalPage)"
+      >
+        {{ finalPage }}
+      </button>
+    </div>
     <button
-      class="focus:outline-none"
+      class="focus:outline-none m-2"
       v-if="currentPage != finalPage"
       @click="next"
     >
@@ -56,7 +78,7 @@
       >
     </button>
     <button
-      class="focus:outline-none disabled:opacity-50 ..."
+      class="focus:outline-none disabled:opacity-50 m-2"
       disabled
       v-else
     >
@@ -86,7 +108,9 @@ export default {
     changePage(index) {
       this.$emit('change-page', index);
     },
-    getShownPages() {
+  },
+  computed: {
+    shownPages() {
       const split = 2;
       let startAt;
       if (Math.floor(this.currentPage + this.pageSlots / split) > this.finalPage) {

--- a/app/javascript/components/base/base-pagination.vue
+++ b/app/javascript/components/base/base-pagination.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="flex w-90 justify-center m-2"
-    v-if="finalPage != 1"
+    v-if="finalPage > 1"
   >
     <button
       class="focus:outline-none m-2"

--- a/app/javascript/components/base/base-pagination.vue
+++ b/app/javascript/components/base/base-pagination.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="flex w-90 justify-end m-2">
+  <div
+    class="flex w-90 justify-end m-2"
+    v-if="finalPage != 1"
+  >
     <button
       class="focus:outline-none"
       v-if="currentPage != 1"

--- a/app/javascript/components/base/base-pagination.vue
+++ b/app/javascript/components/base/base-pagination.vue
@@ -1,0 +1,99 @@
+<template>
+  <div class="flex w-90 justify-end m-2">
+    <button
+      class="focus:outline-none"
+      v-if="currentPage != 1"
+      @click="prev"
+    >
+      <img
+        class="h-5 w-5 text-white"
+        svg-inline
+        src="../../../assets/images/keyboard-arrow-left-svg.svg"
+      >
+    </button>
+    <button
+      class="focus:outline-none disabled:opacity-50 ..."
+      disabled
+      v-else
+    >
+      <img
+        class="h-5 w-5 text-white"
+        svg-inline
+        src="../../../assets/images/keyboard-arrow-left-svg.svg"
+      >
+    </button>
+    <div
+      v-for="index in getShownPages()"
+      :key="index"
+    >
+      <button
+        class="bg-yellow-500 focus:outline-none w-5"
+        v-if="index === currentPage"
+        @click="changePage(index)"
+      >
+        {{ index }}
+      </button>
+      <button
+        class="focus:outline-none w-5"
+        v-else
+        @click="changePage(index)"
+      >
+        {{ index }}
+      </button>
+    </div>
+    <button
+      class="focus:outline-none"
+      v-if="currentPage != finalPage"
+      @click="next"
+    >
+      <img
+        class="h-5 w-5 text-white"
+        svg-inline
+        src="../../../assets/images/keyboard-arrow-right-svg.svg"
+      >
+    </button>
+    <button
+      class="focus:outline-none disabled:opacity-50 ..."
+      disabled
+      v-else
+    >
+      <img
+        class="h-5 w-5 text-white"
+        svg-inline
+        src="../../../assets/images/keyboard-arrow-right-svg.svg"
+      >
+    </button>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    finalPage: { type: Number, required: true },
+    currentPage: { type: Number, required: true },
+    pageSlots: { type: Number, default: 6 },
+  },
+  methods: {
+    prev() {
+      this.$emit('prev');
+    },
+    next() {
+      this.$emit('next');
+    },
+    changePage(index) {
+      this.$emit('change-page', index);
+    },
+    getShownPages() {
+      const split = 2;
+      let startAt;
+      if (Math.floor(this.currentPage + this.pageSlots / split) > this.finalPage) {
+        startAt = Math.max(this.finalPage - this.pageSlots + 1, 1);
+      } else {
+        startAt = Math.max(this.currentPage - Math.floor(this.pageSlots / split), 1);
+      }
+
+      return [...Array(Math.min(this.finalPage, this.pageSlots)).keys()].map(i => i + startAt);
+    },
+  },
+};
+</script>

--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -89,7 +89,9 @@
           class="flex 2xl:justify-center items-center"
         >
           <ingredients-table
-            :ingredients="filteredIngredients"
+            :ingredients="filterIngredients"
+            :page-size="2"
+            :filter="searchQuery"
             @edit="toggleEditModal"
             @del="toggleDelModal"
             @updateInventory="UpdateInventory"

--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -89,7 +89,7 @@
           class="flex 2xl:justify-center items-center"
         >
           <ingredients-table
-            :ingredients="filterIngredients"
+            :ingredients="filteredIngredients"
             :page-size="8"
             :filter="searchQuery"
             @edit="toggleEditModal"

--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -90,7 +90,7 @@
         >
           <ingredients-table
             :ingredients="filterIngredients"
-            :page-size="2"
+            :page-size="8"
             :filter="searchQuery"
             @edit="toggleEditModal"
             @del="toggleDelModal"

--- a/app/javascript/components/ingredients/ingredients-table.vue
+++ b/app/javascript/components/ingredients/ingredients-table.vue
@@ -208,7 +208,6 @@ export default {
   },
   watch: {
     ingredients() {
-      this.finalPage();
       if (this.currentPage > this.finalPage) {
         this.currentPage = this.finalPage;
       }

--- a/app/javascript/components/ingredients/ingredients-table.vue
+++ b/app/javascript/components/ingredients/ingredients-table.vue
@@ -34,7 +34,7 @@
       </thead>
       <tbody class="bg-gray-200">
         <tr
-          v-for="(ingredient, idx) in ingredients"
+          v-for="(ingredient, idx) in pageIngredients"
           :key="ingredient.id"
           class="bg-white border-2 border-gray-200 text-left font-normal"
         >
@@ -131,6 +131,13 @@
         </tr>
       </tbody>
     </table>
+    <base-pagination
+      :current-page="currentPage"
+      :final-page="finalPage"
+      @next="nextPage"
+      @prev="prevPage"
+      @change-page="changePage"
+    />
   </div>
 </template>
 
@@ -143,14 +150,26 @@ export default {
   },
   props: {
     ingredients: { type: Array, required: true },
+    pageSize: { type: Number, required: true },
+    filter: { type: String, required: true },
   },
 
   data() {
     return {
       originalIngredients: [...this.ingredients].map(element => JSON.parse(JSON.stringify(element))),
+      currentPage: 1,
     };
   },
-
+  computed: {
+    pageIngredients() {
+      return this.ingredients.slice(
+        (this.currentPage - 1) * this.pageSize, Math.min(
+          this.ingredients.length, this.currentPage * this.pageSize));
+    },
+    finalPage() {
+      return Math.ceil(this.ingredients.length / this.pageSize);
+    },
+  },
   methods: {
     editIngredient(element) {
       this.$emit('edit', element);
@@ -176,6 +195,26 @@ export default {
       const finalRowsCount = 2;
 
       return idx >= this.ingredients.length - finalRowsCount;
+    },
+    nextPage() {
+      this.currentPage += 1;
+    },
+    prevPage() {
+      this.currentPage -= 1;
+    },
+    changePage(index) {
+      this.currentPage = index;
+    },
+  },
+  watch: {
+    ingredients() {
+      this.finalPage();
+      if (this.currentPage > this.finalPage) {
+        this.currentPage = this.finalPage;
+      }
+    },
+    filter() {
+      this.currentPage = 1;
     },
   },
 };

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -14,6 +14,7 @@ import BaseOneColumnTable from '../components/base/base-one-column-table';
 import BaseErrorParagraph from '../components/base/base-error-paragraph';
 import BaseAlert from '../components/base/base-alert';
 import BaseMoney from '../components/base/base-money';
+import BasePagination from '../components/base/base-pagination';
 
 import TopNavbar from '../components/layout/top-navbar.vue';
 import SideNavbar from '../components/layout/side-navbar.vue';
@@ -49,6 +50,7 @@ Vue.component('BaseOneColumnTable', BaseOneColumnTable);
 Vue.component('BaseErrorParagraph', BaseErrorParagraph);
 Vue.component('BaseAlert', BaseAlert);
 Vue.component('BaseMoney', BaseMoney);
+Vue.component('BasePagination', BasePagination);
 
 Vue.component('TopNavbar', TopNavbar);
 Vue.component('SideNavbar', SideNavbar);


### PR DESCRIPTION
# Que se hizo?
Ahora se ven 8 ingredientes por pagina en la tabla de ingredientes. Si tienes mas de 8 ingredientes aparecen un indice con flechas abajo para moverse entre las paginas.
![image](https://user-images.githubusercontent.com/37181021/125387379-ccafa100-e36b-11eb-9df9-55d0dd6ca04b.png)

# QA
Crear hartos ingredientes y que tanto al filtrar como al moverse entre las paginas no haya ningun problema. Que se marque correctamente en la pagina que se está actualmente y que se recalculen las paginas totales cuando se filra.
# Falta por hacer
No logré hacer que al eliminar o editar un ingrediente permanezcamos en la misma página.
Mejorar estilo