### PR TITLE
fix(recipes): now filters only allow numbers  + some style details

### DIFF
--- a/app/javascript/components/layout/side-navbar.vue
+++ b/app/javascript/components/layout/side-navbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col w-20 h-full bg-gray-800">
+  <div class="flex flex-col z-50 w-20 h-full bg-gray-800">
     <a href="/ingredients">
       <side-navbar-item
         :label="$t('msg.ingredients.title')"

--- a/app/javascript/components/layout/top-navbar.vue
+++ b/app/javascript/components/layout/top-navbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="flex flex-col h-20 sm:flex-row items-center justify-between bg-black sm:h-16">
+  <nav class="flex flex-col z-50 h-20 sm:flex-row items-center justify-between bg-black sm:h-16">
     <!--Left Buttons -->
     <div class="flex items-center text-white ml-4">
       <a

--- a/app/javascript/components/recipes/base/recipe-ingredients.vue
+++ b/app/javascript/components/recipes/base/recipe-ingredients.vue
@@ -1,8 +1,8 @@
 /* eslint-disable vue/max-len */
 <template>
-  <div class="flex justify-between mb-8">
+  <div class="flex flex-col lg:flex-row justify-between mb-8">
     <!-- igredientes para agregar -->
-    <div class="w-1/2 p-4">
+    <div class="w-full lg:w-1/2 p-4">
       <div class="flex flex-col">
         <!-- buscador -->
         <input
@@ -44,7 +44,7 @@
       </div>
     </div>
     <!-- ingredientes seleccionados -->
-    <div class="w-1/2 p-4">
+    <div class="w-full lg:w-1/2 p-4">
       <div class="flex flex-col self-stretch flex-grow bg-gray-50">
         <div class="flex h-6 bg-gray-50 font-sans font-medium text-base text-black self-stretch mb-3">
           {{ $t('msg.recipes.selectedIngredients') }} ({{ recipeIngredients.length }})

--- a/app/javascript/components/recipes/edit/recipe-edit.vue
+++ b/app/javascript/components/recipes/edit/recipe-edit.vue
@@ -43,59 +43,51 @@
       >
         1. {{ $t('msg.recipes.basic') }}
       </div>
-      <div class="flex flex-col">
-        <div class="flex items-start justify-between h-16 flex-none self-stretch flex-grow-0 mb-8">
-          <div class="relative w-2/5">
-            <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-2">
-              {{ $t('msg.recipes.name') }}
-            </div>
-            <input
-              class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
-              v-model="recipe.name"
-            >
-            <p
-              v-if="errors.name"
-              class="mt-2 ml-1 text-xs text-red-400"
-            >
-              {{ $t(`msg.${errors.name}`) }}
-            </p>
+      <div class="flex flex-col xl:flex-row items-start justify-between mb-8 px-4">
+        <div class="relative w-3/5 xl:w-2/5 py-2">
+          <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-1">
+            {{ $t('msg.recipes.name') }}
           </div>
-          <div class="relative w-1/4">
-            <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-2">
-              {{ $t('msg.recipes.portions') }}
-            </div>
-            <input
-              type="number"
-              :min="0"
-              oninput="validity.valid||(value='0');"
-              class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
-              v-model="recipe.portions"
-            >
-            <p
-              v-if="errors.portions"
-              class="mt-2 ml-1 text-xs text-red-400"
-            >
-              {{ $t(`msg.${errors.portions}`) }}
-            </p>
+          <input
+            class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
+            v-model="recipe.name"
+          >
+          <p
+            v-if="errors.name"
+            class="mt-2 ml-1 text-xs text-red-400"
+          >
+            {{ $t(`msg.${errors.name}`) }}
+          </p>
+        </div>
+        <div class="relative w-2/5 xl:w-1/4 py-2">
+          <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-1">
+            {{ $t('msg.recipes.portions') }}
           </div>
-          <div class="relative w-1/4">
-            <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-2">
-              {{ $t('msg.recipes.preparation') }}
-            </div>
-            <input
-              type="number"
-              :min="0"
-              oninput="validity.valid||(value='0');"
-              class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
-              v-model="recipe.cookMinutes"
-            >
-            <p
-              v-if="errors.cookMinutes"
-              class="mt-2 ml-1 text-xs text-red-400"
-            >
-              {{ $t(`msg.${errors.cookMinutes}`) }}
-            </p>
+          <input
+            class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
+            v-model="recipe.portions"
+          >
+          <p
+            v-if="errors.portions"
+            class="mt-2 ml-1 text-xs text-red-400"
+          >
+            {{ $t(`msg.${errors.portions}`) }}
+          </p>
+        </div>
+        <div class="relative w-2/5 xl:w-1/4 py-2">
+          <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-1">
+            {{ $t('msg.recipes.preparation') }}
           </div>
+          <input
+            class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
+            v-model="recipe.cookMinutes"
+          >
+          <p
+            v-if="errors.cookMinutes"
+            class="mt-2 ml-1 text-xs text-red-400"
+          >
+            {{ $t(`msg.${errors.cookMinutes}`) }}
+          </p>
         </div>
       </div>
       <!-- Ingredients -->

--- a/app/javascript/components/recipes/index/filter-popup-content.vue
+++ b/app/javascript/components/recipes/index/filter-popup-content.vue
@@ -11,6 +11,7 @@
         </p>
         <input
           class="px-4 w-50 h-12 bg-white border-2 border-solid border-gray-200 box-border rounded flex-grow-0 my-1"
+          type="number"
           :placeholder="$t('msg.min')"
           v-model="filters.price.min"
         >
@@ -21,6 +22,7 @@
         </p>
         <input
           class="px-4 w-50 h-12 bg-white border-2 border-solid border-gray-200 box-border rounded flex-grow-0 my-1"
+          type="number"
           :placeholder="$t('msg.max')"
           v-model="filters.price.max"
         >
@@ -38,6 +40,7 @@
         </p>
         <input
           class="px-4 w-50 h-12 bg-white border-2 border-solid border-gray-200 box-border rounded flex-grow-0 my-1"
+          type="number"
           :placeholder="$t('msg.min')"
           v-model="filters.portions.min"
         >
@@ -48,6 +51,7 @@
         </p>
         <input
           class="px-4 w-50 h-12 bg-white border-2 border-solid border-gray-200 box-border rounded flex-grow-0 my-1"
+          type="number"
           :placeholder="$t('msg.max')"
           v-model="filters.portions.max"
         >

--- a/app/javascript/components/recipes/new/recipe-create.vue
+++ b/app/javascript/components/recipes/new/recipe-create.vue
@@ -49,53 +49,51 @@
       >
         1. {{ $t('msg.recipes.basic') }}
       </div>
-      <div class="flex flex-col">
-        <div class="flex items-start justify-between h-16 flex-none self-stretch flex-grow-0 mb-8">
-          <div class="relative w-2/5">
-            <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-2">
-              {{ $t('msg.recipes.name') }}
-            </div>
-            <input
-              class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
-              v-model="recipe.name"
-            >
-            <p
-              v-if="errors.name"
-              class="mt-2 ml-1 text-xs text-red-400"
-            >
-              {{ $t(`msg.${errors.name}`) }}
-            </p>
+      <div class="flex flex-col xl:flex-row items-start justify-between mb-8 px-4">
+        <div class="relative w-3/5 xl:w-2/5 py-2">
+          <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-1">
+            {{ $t('msg.recipes.name') }}
           </div>
-          <div class="relative w-1/4">
-            <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-2">
-              {{ $t('msg.recipes.portions') }}
-            </div>
-            <input
-              class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
-              v-model="recipe.portions"
-            >
-            <p
-              v-if="errors.portions"
-              class="mt-2 ml-1 text-xs text-red-400"
-            >
-              {{ $t(`msg.${errors.portions}`) }}
-            </p>
+          <input
+            class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
+            v-model="recipe.name"
+          >
+          <p
+            v-if="errors.name"
+            class="mt-2 ml-1 text-xs text-red-400"
+          >
+            {{ $t(`msg.${errors.name}`) }}
+          </p>
+        </div>
+        <div class="relative w-2/5 xl:w-1/4 py-2">
+          <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-1">
+            {{ $t('msg.recipes.portions') }}
           </div>
-          <div class="relative w-1/4">
-            <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-2">
-              {{ $t('msg.recipes.preparation') }}
-            </div>
-            <input
-              class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
-              v-model="recipe.cookMinutes"
-            >
-            <p
-              v-if="errors.cookMinutes"
-              class="mt-2 ml-1 text-xs text-red-400"
-            >
-              {{ $t(`msg.${errors.cookMinutes}`) }}
-            </p>
+          <input
+            class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
+            v-model="recipe.portions"
+          >
+          <p
+            v-if="errors.portions"
+            class="mt-2 ml-1 text-xs text-red-400"
+          >
+            {{ $t(`msg.${errors.portions}`) }}
+          </p>
+        </div>
+        <div class="relative w-2/5 xl:w-1/4 py-2">
+          <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-1">
+            {{ $t('msg.recipes.preparation') }}
           </div>
+          <input
+            class="w-full h-16 bg-gray-50 border border-gray-600 box-border rounded-md flex-none flex-grow-0 px-5"
+            v-model="recipe.cookMinutes"
+          >
+          <p
+            v-if="errors.cookMinutes"
+            class="mt-2 ml-1 text-xs text-red-400"
+          >
+            {{ $t(`msg.${errors.cookMinutes}`) }}
+          </p>
         </div>
       </div>
       <!-- Ingredients -->


### PR DESCRIPTION
Contexto:
- Actualmente los filtros de recetas aceptaban cualquier texto
![image](https://user-images.githubusercontent.com/30879712/125715341-fd8d586d-c764-4700-93a7-603153701d38.png)
- Actualmente, al crear o editar una receta, al achicar un poco la pantalla, el input de tiempo de preparación se fallaba en estilos:
![image](https://user-images.githubusercontent.com/30879712/125715409-9192522e-4d8a-4865-b19b-5ccfad015db8.png)
- Cuando se achicaba la pantalla, también pasaba que se desarmaba la parte de seleccionar ingredientes :
![image](https://user-images.githubusercontent.com/30879712/125717412-89a6b4e5-fc45-4373-b7d7-142e11e0c8e5.png)

**Lo realizado:**
- Ahora los inputs de los filtros solo reciben números.
- En el crear/editar de recetas, al achicarse la pantalla, los inputs pasan a estar en distintas rows.
- Aproveche de eliminar un poco de css innecesario (por eso se ve tanto cambio en las files de create/edit de recipes).
- Hice responsive también la sección de seleccionar ingredientes y los seleccionados
**QA:**
- Filtros solo deberían permitir valores números y funcionar bien.
- Ver que las vistas de crear/editar recetas se vean bien, y si se achica al navegador, los inputs deberían mostrarse en distintas filas, al igual que las secciones de agregar ingredientes y los ingredientes seleccionados