### PR TITLE
feat(ingredients-form): duplicated measures

### DIFF
--- a/app/javascript/api/ingredients.js
+++ b/app/javascript/api/ingredients.js
@@ -1,5 +1,11 @@
 import client from '../auth/authClient.js';
 
+function getIngredient(ingredientId) {
+  return (client
+    .get(`/ingredients/${ingredientId}`, {
+    }));
+}
+
 function getIngredients() {
   return (client
     .get('/ingredients', {
@@ -49,6 +55,7 @@ function getCriticalAssociations(ingredientId) {
 }
 
 export {
+  getIngredient,
   getIngredients,
   postIngredient,
   deleteIngredient,

--- a/app/javascript/components/base/base-modal.vue
+++ b/app/javascript/components/base/base-modal.vue
@@ -26,7 +26,7 @@
           <button
             v-if="back"
             @click="goBack"
-            class="cursor-pointer text-white"
+            class="cursor-pointer text-white focus:outline-none"
           >
             <span
               class="text-white"

--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -112,6 +112,7 @@
         :edit-mode="false"
         :market-ingredient="marketIngredient"
         :ingredient-errors="errors"
+        @resetErrors="cleanErrors"
       />
     </base-modal>
 
@@ -144,6 +145,7 @@
         :edit-mode="true"
         :ingredient="this.ingredientToEdit"
         :ingredient-errors="errors"
+        @resetErrors="cleanErrors"
       />
     </base-modal>
 
@@ -182,8 +184,7 @@
 
 <script>
 
-import Vue from 'vue';
-import { getIngredients, postIngredient, deleteIngredient,
+import { getIngredient, getIngredients, postIngredient, deleteIngredient,
   editIngredient, getCriticalAssociations } from './../../api/ingredients.js';
 import { floatNonZero, intGeqZero, geqZero, requiredField } from '../../utils/validations.js';
 import IngredientsForm from './ingredients-form';
@@ -225,19 +226,7 @@ export default {
   },
 
   async created() {
-    this.loading = true;
-    try {
-      const response = await getIngredients();
-      this.ingredients = response.data.data.map((element) => ({
-        id: element.id,
-        ...element.attributes,
-      }));
-    } catch (error) {
-      this.unexpectedError = true;
-    } finally {
-      this.loading = false;
-    }
-    this.roundInventory();
+    await this.fetchIngredients();
   },
 
   computed: {
@@ -254,6 +243,43 @@ export default {
   },
 
   methods: {
+    async fetchIngredients() {
+      this.loading = true;
+      try {
+        const response = await getIngredients();
+        this.ingredients = response.data.data.map((element) => ({
+          id: element.id,
+          ...element.attributes,
+        }));
+      } catch (error) {
+        this.unexpectedError = true;
+      } finally {
+        this.loading = false;
+      }
+      this.roundInventory();
+    },
+
+    async fetchIngredient(ingredientId) {
+      try {
+        const response = await getIngredient(ingredientId);
+        const element = response.data.data;
+        this.ingredients.forEach((elem, idx) => {
+          if (elem.id === element.id) {
+            this.ingredients[idx] = {
+              id: element.id,
+              ...element.attributes,
+            };
+          }
+
+          const inventory = this.ingredients[idx].inventory;
+          // eslint-disable-next-line no-magic-numbers
+          this.ingredients[idx].inventory = Math.round(inventory * 100) / 100;
+        });
+      } catch (error) {
+        this.unexpectedError = true;
+      }
+    },
+
     closeAlert() {
       this.unexpectedError = false;
     },
@@ -280,7 +306,6 @@ export default {
       if (this.marketIngredient) {
         this.showingAdd = !this.showingAdd;
       } else {
-        // Aqui arreglar si se vuelve a la pagina principal o no
         this.showingAdd = !this.showingAdd;
       }
     },
@@ -328,20 +353,21 @@ export default {
         try {
           this.showingAdd = !this.showingAdd;
           this.loading = true;
-          ingredientsInfo.ingredientMeasuresAttributes = ingredientsInfo
-            .ingredientMeasuresAttributes.filter(unit => unit.name && unit.quantity);
-          const {
-            data:
-            { data: { id, attributes },
-            },
-          } = await postIngredient(ingredientsInfo);
-          this.ingredients.push({ id, ...attributes });
+
+          this.filterMeasures(ingredientsInfo);
+          const { data: { data: { id, attributes } } } = await postIngredient(ingredientsInfo);
+          this.ingredients.unshift({ id, ...attributes });
         } catch (error) {
           this.unexpectedError = true;
         } finally {
           this.loading = false;
         }
       }
+    },
+
+    filterMeasures(ingredientsInfo) {
+      ingredientsInfo.ingredientMeasuresAttributes = ingredientsInfo
+        .ingredientMeasuresAttributes.filter(unit => unit.name && unit.quantity);
     },
 
     async addIngredient() {
@@ -361,29 +387,16 @@ export default {
       this.marketIngredient = productForm;
     },
 
-    addInventoryToIngredient(ingredientsInfo, id) {
-      this.ingredients.forEach(elem => {
-        if (elem.id === id) {
-          ingredientsInfo.inventory = elem.inventory;
-        }
-      });
-
-      return ingredientsInfo;
-    },
-
-    // eslint-disable-next-line max-statements
     async editIngredient() {
       const ingredientsInfo = this.$refs.editIngredientInfo.form;
       if (this.validations(this.$refs.editIngredientInfo.form)) {
         try {
           this.showingEdit = !this.showingEdit;
           this.loading = true;
-          ingredientsInfo.ingredientMeasuresAttributes = ingredientsInfo
-            .ingredientMeasuresAttributes.filter(unit => unit.name && unit.quantity);
           this.addMeasuresToDelete(ingredientsInfo);
-          const ingredientsInfoFinal = this.addInventoryToIngredient(ingredientsInfo, this.ingredientToEdit.id);
-          await editIngredient(this.ingredientToEdit.id, ingredientsInfoFinal);
-          this.updateIngredient(ingredientsInfoFinal);
+
+          await editIngredient(this.ingredientToEdit.id, ingredientsInfo);
+          await this.fetchIngredient(this.ingredientToEdit.id);
         } catch (error) {
           this.unexpectedError = true;
         } finally {
@@ -394,7 +407,9 @@ export default {
 
     addMeasuresToDelete(ingredientsInfo) {
       this.$refs.editIngredientInfo.measuresToDelete
-        .forEach(elem => ingredientsInfo.ingredientMeasuresAttributes.push({ id: elem, _destroy: true }));
+        .forEach(elem => ingredientsInfo.ingredientMeasuresAttributes.push(
+          { id: elem.id, _destroy: true },
+        ));
     },
 
     async deleteIngredient() {
@@ -422,20 +437,6 @@ export default {
       } catch (error) {
         this.unexpectedError = true;
       }
-    },
-
-    async updateIngredient(ingredientEdited) {
-      ingredientEdited.quantity = ingredientEdited.ingredientMeasuresAttributes[0].quantity;
-      ingredientEdited.measure = ingredientEdited.ingredientMeasuresAttributes[0].name;
-      ingredientEdited.id = this.ingredientToEdit.id;
-      ingredientEdited.otherMeasures = { data: [] };
-      ingredientEdited.providerName = ingredientEdited.provider_name;
-      ingredientEdited.ingredientMeasuresAttributes.forEach(element => {
-        ingredientEdited.otherMeasures.data
-          .push({ id: element.id, attributes: { name: element.name, quantity: element.quantity } });
-      });
-      const objectIndex = this.ingredients.findIndex((obj => obj.id === this.ingredientToEdit.id));
-      Vue.set(this.ingredients, objectIndex, ingredientEdited);
     },
 
     cleanErrors() {

--- a/app/javascript/components/ingredients/ingredients-container.vue
+++ b/app/javascript/components/ingredients/ingredients-container.vue
@@ -210,8 +210,8 @@ export default {
       unexpectedError: false,
       errors: {
         name: '',
-        quantity: '',
-        measure: '',
+        quantity: [],
+        measure: [],
         price: '',
         minimumQuantity: '',
       },
@@ -450,14 +450,16 @@ export default {
 
     validations(form) {
       this.cleanErrors();
-      const correctMeasures = this.measuresValidations(form);
-
       this.errors.price = intGeqZero(form.price, this.errors.price);
       this.errors.minimumQuantity = geqZero(form.minimumQuantity, this.errors.minimumQuantity);
       this.errors.name = requiredField(form.name, this.errors.name);
       this.errors.price = requiredField(form.price, this.errors.price);
 
-      return correctMeasures && !(Object.values(this.errors).some(value => !!value));
+      const errorsCopy = JSON.parse(JSON.stringify(this.errors));
+      const correctAttributes = !(Object.values(errorsCopy).some(value => value.length > 0));
+      const correctMeasures = this.measuresValidations(form);
+
+      return correctAttributes && correctMeasures;
     },
 
     measuresValidations(form) {
@@ -479,10 +481,10 @@ export default {
     duplicatedMeasuresValidations(form) {
       let correct = true;
       const auxiliaryMeasureAttributes = JSON.parse(JSON.stringify(form.ingredientMeasuresAttributes));
-      const names = auxiliaryMeasureAttributes.map((unit) => unit.name.toLowerCase());
+      const names = auxiliaryMeasureAttributes.map((unit) => unit.name && unit.name.toLowerCase());
 
       auxiliaryMeasureAttributes.forEach((pair, idx) => {
-        if (names.filter((value) => value === pair.name.toLowerCase()).length > 1) {
+        if (names.filter((value) => pair.name && value === pair.name.toLowerCase()).length > 1) {
           this.errors.measure[idx] = 'duplicatedMeasure';
           correct = false;
         }

--- a/app/javascript/components/ingredients/ingredients-form.vue
+++ b/app/javascript/components/ingredients/ingredients-form.vue
@@ -75,7 +75,7 @@
         >
           {{ $t('msg.ingredients.alternativeUnit') }}
         </div>
-        <div class="flex -mx-3 w-96 items-center">
+        <div class="flex -mx-3 w-96 items-start">
           <div class="w-full md:w-2/5 px-3 mb-0 md:mb-6">
             <!--Quantity -->
             <label
@@ -91,10 +91,11 @@
               min="1"
               type="number"
               :placeholder="unit.name"
+              ref="quantityInput"
               @change="autoAddUnit(unit)"
             >
             <base-error-paragraph
-              :msg-error="ingredientErrors.quantity"
+              :msg-error="ingredientErrors.quantity[index]"
             />
           </div>
           <div class="w-full px-3 mb-6">
@@ -136,7 +137,7 @@
               </button>
             </div>
             <base-error-paragraph
-              :msg-error="ingredientErrors.measure"
+              :msg-error="ingredientErrors.measure[index]"
             />
           </div>
         </div>

--- a/app/javascript/components/ingredients/market-ingredient.vue
+++ b/app/javascript/components/ingredients/market-ingredient.vue
@@ -43,7 +43,7 @@ export default {
     imgUrl: { type: String, required: true },
     name: { type: String, required: true },
     price: { type: Number, required: true },
-    packageDescription: { type: String, required: true },
+    packageDescription: { type: String, required: false, default: '' },
   },
   data() {
     return {

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -28,6 +28,7 @@ export default {
     geqZero: 'Debe ser mayor o igual a cero',
     intGeqZero: 'Debe ser un entero mayor o igual a cero',
     invalidEmail: 'El correo no es válido',
+    duplicatedMeasure: 'Esta medida está duplicada',
 
     users: {
       registerTitle: 'Crear cuenta',

--- a/app/models/ingredient_measure.rb
+++ b/app/models/ingredient_measure.rb
@@ -2,7 +2,6 @@ class IngredientMeasure < ApplicationRecord
   include PowerTypes::Observable
   belongs_to :ingredient
 
-  validates :name, presence: true, uniqueness: { scope: :ingredient_id }
   validates :quantity, presence: true
 end
 
@@ -17,11 +16,6 @@ end
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  primary       :boolean          default(FALSE)
-#
-# Indexes
-#
-#  index_ingredient_measures_on_ingredient_id           (ingredient_id)
-#  index_ingredient_measures_on_name_and_ingredient_id  (name,ingredient_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/serializers/api/v1/ingredient_serializer.rb
+++ b/app/serializers/api/v1/ingredient_serializer.rb
@@ -20,7 +20,8 @@ class Api::V1::IngredientSerializer < ActiveModel::Serializer
 
   def other_measures
     ActiveModelSerializers::SerializableResource.new(
-      object.ingredient_measures, each_serializer: Api::V1::IngredientMeasureSerializer
+      object.ingredient_measures.order(primary: :desc),
+      each_serializer: Api::V1::IngredientMeasureSerializer
     )
   end
 

--- a/db/migrate/20210720031655_remove_duplicated_measure_index.rb
+++ b/db/migrate/20210720031655_remove_duplicated_measure_index.rb
@@ -1,0 +1,6 @@
+class RemoveDuplicatedMeasureIndex < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :ingredient_measures, name: "index_ingredient_measures_on_ingredient_id"
+    remove_index :ingredient_measures, name: "index_ingredient_measures_on_name_and_ingredient_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_05_235054) do
+ActiveRecord::Schema.define(version: 2021_07_20_031655) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,8 +48,6 @@ ActiveRecord::Schema.define(version: 2021_07_05_235054) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "primary", default: false
-    t.index ["ingredient_id"], name: "index_ingredient_measures_on_ingredient_id"
-    t.index ["name", "ingredient_id"], name: "index_ingredient_measures_on_name_and_ingredient_id", unique: true
   end
 
   create_table "ingredients", force: :cascade do |t|


### PR DESCRIPTION
BASE #209 

Algunos arreglos de diseño y validaciones:
- Ahora las validaciones de quantity y measure son de todas, no solo la primera
- Medidas duplicadas

![image](https://user-images.githubusercontent.com/30879716/126084716-c11766d7-7dea-422a-b4e1-4dd9da510333.png)

Antes si habían medidas duplicadas simplemente decía "Oops ocurrió un error"

Además, cambio la forma en que se agregan/updatean/quitan las measures tanto en back (para mobile) como en front, para así no tener problemas cambiando la primary