### PR TITLE
fix(menus/dropdown): fix overflow

### DIFF
--- a/app/javascript/components/menus/index/menus-container.vue
+++ b/app/javascript/components/menus/index/menus-container.vue
@@ -52,7 +52,7 @@
         </p>
         <div
           v-else
-          class="flex w-full 2xl:justify-center items-center overflow-auto"
+          class="flex w-full 2xl:justify-center items-center"
         >
           <menus-table
             :menus="filteredMenus"


### PR DESCRIPTION
## Contexto
Si se tenía un solo menú, al dropdown con las opciones de eliminar y editar quedaba escondido por el header de la tabla

## Lo que hice
El div que contiene a la tabla tenía un "overflow-auto" pero no era necesario y era lo que estaba provocando el problema así que lo saqué

## QA
Ir a /menus y tener solo un menú y apretar los 3 puntitos para que se abra el dropdown y verificar que las opciones no queden tapadas

Antes ocurría esto, pero ya no se esconde
![Captura de Pantalla 2021-07-19 a la(s) 10 48 32](https://user-images.githubusercontent.com/48369511/126179505-aaef1627-555a-4961-bb29-22d42471fe12.png)

