### PR TITLE
style(web): refactor of mobile views

### DIFF
--- a/app/javascript/components/ingredients/ingredients-table.vue
+++ b/app/javascript/components/ingredients/ingredients-table.vue
@@ -1,35 +1,35 @@
 <template>
-  <div class="w-full">
+  <div class="w-full flex flex-col overflow-auto lg:overflow-visible">
     <table
       class="w-full divide-y divide-gray-200"
     >
       <thead class="justify-between bg-gray-600 border-2 border-gray-600">
         <tr class="text-left items-center">
-          <th class="pl-6 py-3 w-72">
+          <th class="pl-2 w-4 py-3">
             <span class="text-white font-bold">{{ $t('msg.ingredients.name') }}</span>
           </th>
-          <th class="px-4 py-3">
+          <th class="pl-1 w-4 py-3">
             <span class="text-white font-bold">{{ $t('msg.ingredients.provider') }}</span>
           </th>
-          <th class="px-4 py-3">
+          <th class="pl-1 w-4 py-3">
             <span class="text-white font-bold">{{ $t('msg.ingredients.price') }}</span>
           </th>
-          <th class="px-4 py-3">
+          <th class="pl-1 w-4 py-3">
             <span class="text-white font-bold">{{ $t('msg.ingredients.quantity') }}</span>
           </th>
-          <th class="px-4 py-3">
+          <th class="pl-1 w-4 py-3">
             <span class="text-white font-bold">{{ $t('msg.ingredients.measure') }}</span>
           </th>
-          <th class="px-4 py-3">
+          <th class="pl-1 pr-4 w-4 py-3">
             <span class="text-white font-bold">{{ $t('msg.ingredients.unitPrice') }}</span>
           </th>
-          <th class="px-4 py-3">
+          <th class="pl-1 w-14 py-3">
             <span class="text-white font-bold">{{ $t('msg.ingredients.inventory.title') }}</span>
           </th>
-          <th class="py-3">
+          <th class="pl-1 w-14 py-3">
             <span class="text-white font-bold">{{ $t('msg.ingredients.minimumQuantityShort') }}</span>
           </th>
-          <th class="px-4 py-3" />
+          <th class="pl-1 w-6 py-3" />
         </tr>
       </thead>
       <tbody class="bg-gray-200">
@@ -39,46 +39,46 @@
           class="bg-white border-2 border-gray-200 text-left font-normal"
         >
           <!-- ingredient name -->
-          <td class="pl-6 py-3">
+          <td class="pl-2 w-6 py-3">
             <p>
               {{ ingredient.name }}
             </p>
           </td>
-          <td class="px-4 py-3">
+          <td class="pl-1 w-4 py-3">
             <p>
               {{ ingredient.providerName === null ? "-" : ingredient.providerName }}
             </p>
           </td>
           <!-- price -->
-          <td class="py-2 px-4">
+          <td class="pl-1 w-4 py-3">
             <p>
               {{ ingredient.price | currency }}
             </p>
           </td>
           <!-- quantity -->
-          <td class="py-2 px-4">
+          <td class="pl-1 w-4 py-3">
             <p>
               {{ ingredient.quantity }}
             </p>
           </td>
-          <td class="py-2 px-4">
+          <td class="pl-1 w-4 py-3">
             <p>
               {{ ingredient.measure }}
             </p>
           </td>
-          <td class="py-2 px-4">
+          <td class="pl-1 w-4 py-3">
             <ingredients-table-unit-price
               :ingredient="ingredient"
             />
           </td>
-          <td class="py-2 px-4">
+          <td class="pl-1 w-14 py-3">
             <div
               class="flex justify-start"
             >
               <img
                 svg-inline
                 src="../../../assets/images/pencil-svg.svg"
-                class="w-4 h-4 cursor-pointer"
+                class="w-3 h-3 my-auto cursor-pointer"
                 @click="openEditInventory(idx)"
               >
               <div class="flex">
@@ -86,25 +86,25 @@
                   type="number"
                   min="0"
                   ref="inventory"
-                  class="w-12 m-auto border-none outline-none text-center"
+                  class="w-10 m-auto border-none outline-none text-center"
                   v-model="ingredient.inventory"
                   @blur.prevent="changeInventory(ingredient, ingredient.inventory)"
                 >
-                <div class="flex m-auto">
+                <div class="m-auto hidden lg:flex">
                   {{ ingredient.measure }}
                 </div>
               </div>
             </div>
           </td>
           <!-- minimum quantity -->
-          <td class="py-2">
+          <td class="pl-1 w-14 py-3">
             <div
               class="flex justify-start"
             >
               <img
                 svg-inline
                 src="../../../assets/images/pencil-svg.svg"
-                class="w-4 h-4 cursor-pointer"
+                class="w-3 h-3 my-auto cursor-pointer"
                 @click="openEditMinimumQuantity(idx)"
               >
               <div class="flex">
@@ -112,18 +112,19 @@
                   type="number"
                   min="0"
                   ref="minimumQuantity"
-                  class="w-12 m-auto border-none outline-none text-center"
+                  class="w-10 m-auto border-none outline-none text-center"
                   v-model="ingredient.minimumQuantity"
                   @blur.prevent="changeMinimumQuantity(ingredient, ingredient.minimumQuantity)"
                 >
-                <div class="flex m-auto">
+                <div class="m-auto hidden lg:flex">
                   {{ ingredient.measure }}
                 </div>
               </div>
             </div>
           </td>
-          <td class="content-center">
+          <td class="pl-1 w-6 py-3">
             <dots-dropdown
+              class="w-6"
               :elements="{
                 edit: true,
                 del: true,

--- a/app/javascript/components/menus/index/menus-table.vue
+++ b/app/javascript/components/menus/index/menus-table.vue
@@ -1,40 +1,40 @@
 <template>
-  <div class="w-full">
+  <div class="w-full md:overflow-visible overflow-auto">
     <table class="w-full divide-y divide-gray-200">
       <thead class="justify-between bg-gray-600 border-2 border-gray-600">
         <tr class="text-left">
           <th
-            class="px-6 py-3 w-60"
+            class="w-6 pl-2 py-3 w-60"
           >
             <span class="text-white font-bold">{{ $t('msg.menus.name') }}</span>
           </th>
           <th
-            class="px-6 py-3"
+            class="w-6 pl-2 py-3"
           >
             <span class="text-white font-bold">{{ $t('msg.menus.totalCost') }}</span>
           </th>
           <th
-            class="px-6 py-3"
+            class="w-6 pl-2 py-3"
           >
             <span class="text-white font-bold">{{ $t('msg.menus.portions') }}</span>
           </th>
           <th
-            class="px-6 py-3"
+            class="w-6 pl-2 py-3"
           >
             <span class="text-white font-bold">{{ $t('msg.menus.recipesQuantity') }}</span>
           </th>
           <th
-            class="px-6 py-3"
+            class="w-6 pl-2 py-3"
           >
             <span class="text-white font-bold">{{ $t('msg.menus.recipes') }}</span>
           </th>
           <th
-            class="px-6 py-3"
+            class="w-6 pl-2 py-3"
           >
             <span class="text-white font-bold">{{ $t('msg.menus.actions') }}</span>
           </th>
           <th
-            class="px-4 py-3"
+            class="w-6 py-3"
           />
         </tr>
       </thead>
@@ -47,7 +47,7 @@
           <!-- name -->
           <td
             key="name"
-            class="py-2 px-6"
+            class="py-2 w-6 pl-2"
           >
             <p>
               {{ menu.name }}
@@ -56,7 +56,7 @@
           <!-- totalPrice -->
           <td
             key="totalPrice"
-            class="py-2 px-6"
+            class="py-2 w-6 pl-2"
           >
             <p>
               {{ totalMenuPrice(menu.menuRecipes.data) | currency }}
@@ -64,7 +64,7 @@
           </td>
           <td
             key="portions"
-            class="py-2 px-6"
+            class="py-2 w-6 pl-2"
           >
             <p>
               {{ menu.portions }}
@@ -73,7 +73,7 @@
           <!-- recipesQuantity -->
           <td
             key="recipesQuantity"
-            class="py-2 px-6"
+            class="py-2 w-6 pl-2"
           >
             <menus-table-recipes-quantity
               :menu="menu"
@@ -82,14 +82,14 @@
           <!-- recipes -->
           <td
             key="recipes"
-            class="py-2 px-6"
+            class="py-2 w-6 pl-2"
           >
             <menus-table-recipes
               :menu="menu"
             />
           </td>
           <td
-            class="content-center py-4 px-6 items-center"
+            class="content-center py-4 w-6 pl-2 items-center"
           >
             <div class="flex flex-col">
               <menu-shopping-list
@@ -114,9 +114,10 @@
             </div>
           </td>
           <td
-            class="content-center"
+            class="content-center w-6 pl-1"
           >
             <dots-dropdown
+              class="w-6"
               :elements="{
                 edit:true,
                 del:true,
@@ -261,8 +262,8 @@ export default {
       const listOfMessages = menuIngredients.map((obj) =>
         obj.ingredients.map((element) =>
           `Has reducido ${Math.round(element.quantity * this.numberToGetDecimals) / this.numberToGetDecimals}
-          ${element.measure} de <strong>${element.name} </strong> y quedaste en <strong> 
-          ${Math.round(element.inventory * this.numberToGetDecimals) / this.numberToGetDecimals} 
+          ${element.measure} de <strong>${element.name} </strong> y quedaste en <strong>
+          ${Math.round(element.inventory * this.numberToGetDecimals) / this.numberToGetDecimals}
           ${element.measure} </strong>`,
         ));
 

--- a/app/javascript/components/menus/new/new-menu-container.vue
+++ b/app/javascript/components/menus/new/new-menu-container.vue
@@ -23,10 +23,10 @@
       @closeAlert="closeAlert"
     />
 
-    <div class="flex flex-col py-8 px-6 w-auto h-auto bg-gray-50 flex-grow-0 my-10">
+    <div class="flex flex-col py-6 px-6 w-auto h-auto bg-gray-50 flex-grow-0 my-8">
       <!-- Menu Name -->
-      <div class="flex flex-col xl:flex-row items-start justify-start mb-8 px-4">
-        <div class="mr-5 relative w-3/5 xl:w-2/5 py-2">
+      <div class="flex flex-col xl:flex-row items-start justify-start 4 px-4">
+        <div class="mr-5 relative w-3/5 xl:w-2/5 pt-2 pb-4">
           <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-2">
             {{ $t('msg.recipes.name') }}
           </div>

--- a/app/javascript/components/providers/index/provider-index-component.vue
+++ b/app/javascript/components/providers/index/provider-index-component.vue
@@ -32,7 +32,7 @@
     />
 
     <!-- info -->
-    <div class="flex flex-col pt-6 pb-10 px-10 w-auto h-auto bg-gray-50 flex-grow-0 my-10">
+    <div class="flex flex-col pt-6 px-1 sm:pb-10 sm:px-10 w-auto h-auto bg-gray-50 flex-grow-0 my-10">
       <!-- searchBar y button -->
       <div class="flex flex-col lg:flex-row pb-6">
         <div class="flex items-center py-2 pr-2 lg:w-1/2">
@@ -45,14 +45,14 @@
               >
             </span>
             <input
-              class="w-full py-2 pl-12 bg-gray-50 border-2 border-gray-600 rounded self-stretch focus:outline-none z-200"
+              class="w-full py-2 pl-10 sm:pl-12 bg-gray-50 border-2 border-gray-600 rounded self-stretch focus:outline-none z-200"
               :placeholder="$t('msg.providers.search')"
               @keyup="filterProviders"
               v-model="searchQuery"
             >
           </div>
         </div>
-        <div class="flex justify-end w-full">
+        <div class="flex justify-center sm:justify-end w-full">
           <a
             class="my-2 h-10 font-bold py-2 px-6 rounded shadow-md flex-shrink-0 bg-green-500 hover:bg-green-700 text-white cursor-pointer"
             @click="toggleAddModal"
@@ -73,7 +73,7 @@
         </span>
       </div>
       <div
-        class="flex flex-col justify-center bg-gray-50 m-auto md:flex-row md:flex-wrap md:px-8"
+        class="flex flex-col w-full justify-center bg-gray-50 m-auto sm:flex-row sm:flex-wrap sm:px-8"
       >
         <p
           v-if="this.providers.length===0 && !loading"
@@ -83,11 +83,11 @@
         </p>
         <div
           v-else
-          class="flex bg-gray-50 px-16"
+          class="flex bg-gray-50 w-full sm:px-16"
           v-for="element in filterProviders"
           :key="element.id"
         >
-          <div>
+          <div class="w-full px-1">
             <provider-item
               :provider="element"
               @update="updateProvider"

--- a/app/javascript/components/providers/index/provider-index-component.vue
+++ b/app/javascript/components/providers/index/provider-index-component.vue
@@ -83,11 +83,11 @@
         </p>
         <div
           v-else
-          class="flex bg-gray-50 w-full sm:px-16"
+          class="flex bg-gray-50 w-full md:w-auto sm:px-16"
           v-for="element in filterProviders"
           :key="element.id"
         >
-          <div class="w-full px-1">
+          <div class="w-full md:w-auto px-1">
             <provider-item
               :provider="element"
               @update="updateProvider"

--- a/app/javascript/components/providers/index/provider-item.vue
+++ b/app/javascript/components/providers/index/provider-item.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col m-auto p-2 sm:p-4 border-2 border-solid border-gray-400 box-border mb-6 w-full order-none">
+  <div class="flex flex-col m-auto p-2 sm:p-4 border-2 border-solid border-gray-400 box-border mb-6 w-full md:w-96 order-none">
     <div class="flex flex-row items-center self-stretch mb-4 px-1">
       <!-- Info -->
       <div class="flex flex-col">

--- a/app/javascript/components/providers/index/provider-item.vue
+++ b/app/javascript/components/providers/index/provider-item.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="flex flex-col m-auto p-4 border-2 border-solid border-gray-400 box-border mb-6 w-96 order-none">
-    <div class="flex flex-row items-center w-auto h-auto self-stretch mb-4 px-1">
+  <div class="flex flex-col m-auto p-2 sm:p-4 border-2 border-solid border-gray-400 box-border mb-6 w-full order-none">
+    <div class="flex flex-row items-center self-stretch mb-4 px-1">
       <!-- Info -->
-      <div class="flex flex-col w-auto h-auto self-stretch flex-grow">
+      <div class="flex flex-col">
         <!-- nombre Proveedor -->
         <div
           class="flex items-center cursor-pointer w-auto h-5 text-xl font-bold"
@@ -61,7 +61,7 @@
       </div>
       <!-- flecha -->
       <div
-        class="flex items-center w-6 h-6 self-stretch justify-self-end"
+        class="flex items-center w-6 h-6 justify-self-end"
         @click="toggleOpenModal"
       >
         <div
@@ -87,9 +87,9 @@
     <div
       v-if="showingDetails"
     >
-      <div class="flex flex-col items-start w-full">
+      <div class="flex flex-col items-center sm:items-start w-full">
         <!-- Pagina Web -->
-        <div class="flex flex-row items-start order-none w-full justify-between">
+        <div class="flex flex-col sm:flex-row items-center sm:items-start order-none w-full justify-between">
           <div class="flex flex-row items-center order-none w-48">
             <!-- Icono -->
             <div class="w-4 h-4 m-1.5">
@@ -120,7 +120,7 @@
           </div>
         </div>
         <!-- Datos bancarios -->
-        <div class="flex flex-row items-start order-none w-full justify-between">
+        <div class="flex flex-col sm:flex-row items-center sm:items-start order-none w-full justify-between">
           <div class="flex flex-row items-center order-none w-48">
             <!-- Icono -->
             <div class="w-4 h-4 m-1.5">
@@ -144,7 +144,7 @@
           </button>
         </div>
         <!-- Minimo Compra -->
-        <div class="flex flex-row items-start order-none w-full justify-between">
+        <div class="flex flex-col sm:flex-row items-center sm:items-start order-none w-full justify-between">
           <div class="flex flex-row items-center order-none w-48">
             <!-- Icono -->
             <div class="w-4 h-4 m-1.5">
@@ -174,7 +174,7 @@
           </p>
         </div>
         <!-- Tiempo de Despacho -->
-        <div class="flex flex-row items-start order-none w-full justify-between mb-2">
+        <div class="flex flex-col sm:flex-row items-center sm:items-start order-none w-full justify-between mb-2">
           <div class="flex flex-row items-center order-none w-48">
             <!-- Icono -->
             <div class="w-4 h-4 m-1.5">
@@ -205,8 +205,8 @@
         </div>
       </div>
       <!-- botones -->
-      <div class="flex flex-row items-start order-2 self-stretch w-full justify-between">
-        <div>
+      <div class="flex flex-col sm:flex-row items-center sm:items-start order-2 self-stretch w-full justify-between">
+        <div class="pb-2 sm:pb-0">
           <button
             class="flex flex-row items-center justify-center border-2 border-red-600 hover:bg-gray-300 text-red-600 rounded order-1 flex-grow-1 px-2"
             @click="toggleDelModal"

--- a/app/javascript/components/recipes/edit/recipe-edit.vue
+++ b/app/javascript/components/recipes/edit/recipe-edit.vue
@@ -45,7 +45,7 @@
             :msg-error="errors.name"
           />
         </div>
-        <div class="relative w-2/5 xl:w-1/4 py-2">
+        <div class="relative w-3/5 xl:w-1/4 py-2">
           <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-1">
             {{ $t('msg.recipes.portions') }}
           </div>
@@ -57,7 +57,7 @@
             :msg-error="errors.portions"
           />
         </div>
-        <div class="elative w-2/5 xl:w-1/4 py-2">
+        <div class="relative w-3/5 xl:w-1/4 py-2">
           <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-1">
             {{ $t('msg.recipes.preparation') }}
           </div>

--- a/app/javascript/components/recipes/index/recipes-list/recipes-item-price.vue
+++ b/app/javascript/components/recipes/index/recipes-list/recipes-item-price.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex flex-row p-0 static w-auto h-auto flex-none order-1 flex-grow-0 mx-2.5 items-center">
-    <div class="static font-sans not-italic font-normal text-2xl flex-none order-0 flex-grow-0 mx-2.5 text-yellow-500">
+  <div class="flex flex-row items-center">
+    <div class="font-sans not-italic font-normal text-2xl text-yellow-500">
       {{ recipePrice | currency }}
     </div>
     <div

--- a/app/javascript/components/recipes/index/recipes-list/recipes-item.vue
+++ b/app/javascript/components/recipes/index/recipes-list/recipes-item.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="flex flex-row divide-x-2 divide-gray-400 border-2 border-solid border-gray-400 box-border my-2">
+  <div class="flex flex-col md:flex-row md:divide-x-2 divide-gray-400 border-2 border-solid border-gray-400 box-border my-2">
     <div
-      class="flex flex-row cursor-pointer w-10/12 justify-between items-center p-6 static h-24 bg-white flex-none flex-grow-0 self-stretch"
+      class="flex flex-row cursor-pointer w-full md:w-10/12 justify-between items-center p-6 h-24 bg-white flex-none flex-grow-0 self-stretch"
       @click="goToRecipe"
     >
       <recipes-item-info

--- a/app/javascript/components/recipes/new/recipe-create.vue
+++ b/app/javascript/components/recipes/new/recipe-create.vue
@@ -51,7 +51,7 @@
             :msg-error="errors.name"
           />
         </div>
-        <div class="relative w-2/5 xl:w-1/4 py-2">
+        <div class="relative w-3/5 xl:w-1/4 py-2">
           <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-1">
             {{ $t('msg.recipes.portions') }}
           </div>
@@ -63,7 +63,7 @@
             :msg-error="errors.portions"
           />
         </div>
-        <div class="relative w-2/5 xl:w-1/4 py-2">
+        <div class="relative w-3/5 xl:w-1/4 py-2">
           <div class="text-gray-600 text-sm absolute bg-gray-50 px-1 left-2 -top-1">
             {{ $t('msg.recipes.preparation') }}
           </div>


### PR DESCRIPTION
Hice un poco de cambio en los estilos, sobre todo en la tabla de ingredientes y en el index de proveedores, como se puede ver en el video ahora es responsive en mobile.


### QA

Toqué (alejar, acercar, achicar pantalla y agrandar todas):
- Tabla de menus 
- Nuevo menú / Editar menú
- Tabla de ingredientes
- Providers index / provider card
- Crear receta / Editar receta

Algunos videos:

https://user-images.githubusercontent.com/30879716/126266384-e36eac4b-96fc-44a1-bac7-57306c8ab42c.mov

https://user-images.githubusercontent.com/30879716/126266579-e6a15df4-3ccf-400c-b254-3381ca588c41.mov

https://user-images.githubusercontent.com/30879716/126266632-d3412435-9d64-4a46-896d-22631154bb26.mov

