### PR TITLE
fix(details): inventories and shopping list

### DIFF
--- a/app/controllers/api/v1/menus_controller.rb
+++ b/app/controllers/api/v1/menus_controller.rb
@@ -107,9 +107,9 @@ class Api::V1::MenusController < Api::V1::BaseController
     {
       name: ingredient.name,
       measure: ingredient.measure,
-      quantity: accumulated_quantity,
+      quantity: accumulated_quantity.round(2),
       inventory: ingredient.inventory,
-      total_price: ingredient.price.to_f / ingredient.quantity * accumulated_quantity
+      total_price: (ingredient.price.to_f / ingredient.quantity * accumulated_quantity).round(2)
     }
   end
 

--- a/app/javascript/components/ingredients/ingredients-edit-inventory.vue
+++ b/app/javascript/components/ingredients/ingredients-edit-inventory.vue
@@ -29,7 +29,6 @@
               <input
                 class="w-full py-2 pl-12 bg-gray-50 border-2 border-gray-600 rounded self-stretch focus:outline-none z-200"
                 :placeholder="$t('msg.ingredients.search')"
-                @keyup="filterIngredients"
                 v-model="searchQuery"
               >
             </div>
@@ -58,7 +57,8 @@
             class="flex flex-col w-full 2xl:justify-center items-center overflow-auto"
           >
             <inventory-table
-              :ingredients="filterIngredients"
+              :ingredients="ingredients"
+              :searchQuery="searchQuery"
               @updateIngredientInventory="updateIngredientInventory"
             />
           </div>
@@ -115,19 +115,6 @@ export default {
     this.roundInventory();
   },
 
-  computed: {
-    filterIngredients() {
-      if (this.searchQuery) {
-        return this.ingredients.filter(item => this.searchQuery
-          .toLowerCase()
-          .split(' ')
-          .every(text => item.name.toLowerCase().includes(text)));
-      }
-
-      return this.ingredients;
-    },
-  },
-
   methods: {
     updateIngredientInventory(ingredient) {
       this.ingredientsToEdit.push(ingredient);
@@ -135,7 +122,7 @@ export default {
     async updateInventory() {
       try {
         const formattedIngredients = this.ingredientsToEdit.map((ingredient) => ({
-          ingredientId: ingredient.id, inventory: ingredient.inventory,
+          ingredientId: ingredient.id, inventory: ingredient.finalInventory,
         }));
 
         if (formattedIngredients.length) {

--- a/app/javascript/components/ingredients/ingredients-edit-inventory.vue
+++ b/app/javascript/components/ingredients/ingredients-edit-inventory.vue
@@ -58,7 +58,7 @@
           >
             <inventory-table
               :ingredients="ingredients"
-              :searchQuery="searchQuery"
+              :search-query="searchQuery"
               @updateIngredientInventory="updateIngredientInventory"
             />
           </div>


### PR DESCRIPTION
No podía terminar el Capstone sin arreglar estas dos cosas :toc:

1. En la vista de editar varios inventarios, se estaban guardando los increase/decrease/finales en una lista por index. Entonces, al buscar algo, quedaba la embarraita. Ahora se hace por ID. Revisé todas las otras tablas y están bien 👌 
2. Ahora en el backend se hace un redondeo de la shopping list, así nunca más se va a ver más de dos decimales en mobile o web.

### QA

- Editar varios inventarios probando negativos, disminuyendo más de lo que tienes, inputs vacíos, y también aplicando búsquedas.
- Descargar shopping list